### PR TITLE
Bug/update postgresql to 42.3.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
 		<!-- framework and base stuff -->
 		<spring.boot.version>2.5.14</spring.boot.version>
 		<spring.cloud.version>2020.0.3</spring.cloud.version>
-		<spring.version>5.3.12</spring.version>
+		<spring.version>5.3.20</spring.version>
 		<spring.feign.version>3.1.3</spring.feign.version>
 		<springdoc.version>1.6.6</springdoc.version>
 		<springfox.version>2.9.2</springfox.version>

--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
 		<!-- persistence -->
 		<mapstruct.version>1.4.2.Final</mapstruct.version>
 		<mapstruct.lombok.version>0.2.0</mapstruct.lombok.version>
-		<postgresql.version>42.2.25</postgresql.version>
+		<postgresql.version>42.3.6</postgresql.version>
 		<h2.version>2.1.210</h2.version>
 		<liquibase.version>4.9.1</liquibase.version>
 


### PR DESCRIPTION
Updating version of used postgressql dependency to 42.3.6 due to the findings in https://github.com/advisories/GHSA-673j-qm5f-xpv8 

Note, that this PR bases on #7 which should be merged before. 