### PR TITLE
Update Helm chart version to 0.2.0

### DIFF
--- a/backend/deployment/registry/Chart.yaml
+++ b/backend/deployment/registry/Chart.yaml
@@ -23,8 +23,8 @@ name: registry
 description: A Helm chart for Kubernetes
 
 type: application
-version: 0.1.0
-appVersion: 0.1.0-M1-multi-tenancy
+version: 0.2.0
+appVersion: 0.2.0-M1-multi-tenancy
 
 dependencies:
   - repository: https://charts.bitnami.com/bitnami

--- a/backend/deployment/registry/values.yaml
+++ b/backend/deployment/registry/values.yaml
@@ -21,7 +21,7 @@
 enablePostgres: true
 
 registry:
-  image: registry:0.1.0-M1-multi-tenancy
+  image: registry:0.2.0-M1-multi-tenancy
   replicaCount: 1
   imagePullPolicy: IfNotPresent
   containerPort: 4242


### PR DESCRIPTION
This commit adjusts the Helm chart version for the Digital Twin Registry to image app version 0.2.0-M1-multi-tenancy.