### PR TITLE
Adjust Helm chart version to 0.2.1

### DIFF
--- a/backend/deployment/registry/Chart.yaml
+++ b/backend/deployment/registry/Chart.yaml
@@ -20,11 +20,11 @@
 
 apiVersion: v2
 name: registry
-description: A Helm chart for Kubernetes
+description: Tractus-X Digital Twin Registry Helm Chart
 
 type: application
-version: 0.2.0
-appVersion: 0.2.0-M1-multi-tenancy
+version: 0.2.1
+appVersion: 0.2.0-M2-multi-tenancy
 
 dependencies:
   - repository: https://charts.bitnami.com/bitnami

--- a/backend/deployment/registry/values.yaml
+++ b/backend/deployment/registry/values.yaml
@@ -21,7 +21,7 @@
 enablePostgres: true
 
 registry:
-  image: registry:0.2.0-M1-multi-tenancy
+  image: registry:0.2.0-M2-multi-tenancy
   replicaCount: 1
   imagePullPolicy: IfNotPresent
   containerPort: 4242


### PR DESCRIPTION
This commit adjusts the Helm chart version to 0.2.1 and appVersion 0.2.0-M2-multi-tenancy.