### PR TITLE
fix cve-2022-42003 (jackson-databind)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
 
 		<!-- json, xml, formats, ... -->
 		<jackson.version>2.13.1</jackson.version>
-		<jackson.databind.version>2.13.4.2</jackson.databind.version>
+		<jackson.databind.version>2.14.0</jackson.databind.version>
 
 		<!-- persistence -->
 		<mapstruct.version>1.4.2.Final</mapstruct.version>


### PR DESCRIPTION
Increase jackson-databind version to 2.14.0