### PR TITLE
Adjust Helm chart release workflow to include workflow_dispatch trigger

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -6,6 +6,8 @@ on:
       - 'charts/**'
     branches:
       - main
+  workflow_dispatch:
+    
 jobs:
   release:
     permissions:


### PR DESCRIPTION
Adjust the Helm chart release workflow for the registry to accept the workflow_dispatch event.