### PR TITLE
Fix a bug in the Helm chart release workflow

### DIFF
--- a/charts/registry/Chart.lock
+++ b/charts/registry/Chart.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: postgresql
-  repository: https://charts.bitnami.com/bitnami
-  version: 11.1.9
-digest: sha256:d94e937189226e296956741bf94853b3f484e582ce6b39ba23760ec682ad1073
-generated: "2022-04-07T16:25:17.18448+02:00"


### PR DESCRIPTION
This fixes a bug in the Helm chart release workflow induced by the Chart.lock file.