### PR TITLE
Fix paths in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The source code under this folder contains reference implementations of the SLDT
 Run `mvn install` to run unit tests, build and install the package.
 
 ## Run Package Locally
-To check whether the build was successful, you can start the resulting JAR file from the build process by running `java -jar target/digital-twin-registry-backend-{current-version}.jar`.
+To check whether the build was successful, you can start the resulting JAR file from the build process by running `java -jar backend/target/digital-twin-registry-backend-{current-version}.jar`.
 
 ## Build Docker
 Run `docker build -t registry .`

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Run `docker build -t registry .`
 In case you want to publish your image into a remote container registry, apply the tag accordingly and `docker push` the image.
 
 ## Deploy using Helm and K8s
-If you have a running Kubernetes cluster available, you can deploy the Registry using our Helm Chart, which is located under `./deployment/registry`.
+If you have a running Kubernetes cluster available, you can deploy the Registry using our Helm Chart, which is located under `charts/registry`.
 In case you don't have a running cluster, you can set up one by yourself locally, using [minikube](https://minikube.sigs.k8s.io/docs/start/).
 In the following, we will use a minikube cluster for reference.
 
@@ -47,11 +47,11 @@ Before deploying the Registry, enable a few add-ons in your minikube cluster by 
 
 `minikube addons enable ingress`
 
-Fetch all dependencies by running `helm dep up deployment/registry`.
+Fetch all dependencies by running `helm dep up charts/registry`.
 
 In order to deploy the helm chart, first create a new namespace "semantics": `kubectl create namespace semantics`.
 
-Then run `helm install registry -n semantics ./deployment/registry`. This will set up a new helm deployment in the semantics namespace. By default, the deployment contains the Registry instance itself, and a Fuseki Triplestore.
+Then run `helm install registry -n semantics charts/registry`. This will set up a new helm deployment in the semantics namespace. By default, the deployment contains the Registry instance itself, and a Fuseki Triplestore.
 
 Check that the two containers are running by calling `kubectl get pod -n semantics`.
 


### PR DESCRIPTION
The paths in the README don't match the current structure in the main branch. If some modification has been made to the repo structure in another branch, maybe that needs to be merged with main. In any case, I propose here a fix for main.