### PR TITLE
Change instruction to adapt /etc/hosts

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -22,7 +22,7 @@ Check that the two containers are running by calling `kubectl get pod -n semanti
 To access the Registry API from the host, you need to configure the `Ingress` resource.
 By default, the Registry includes an `Ingress` that exposes the API on https://minikube/semantics/registry
 
-For that to work, you need to append `/etc/hosts` by running `echo "minikube $(minikube ip)" | sudo tee -a /etc/hosts`.
+For that to work, you need to append `/etc/hosts` by running `echo "$(minikube ip) minikube" | sudo tee -a /etc/hosts`.
 
 For automated certificate generation, use and configure [cert-manager](https://cert-manager.io/).
 By default, authentication is deactivated, please adjust `registry.authentication` if needed


### PR DESCRIPTION
I have setup the digital twin registry following the INSTALL.md on minikube. There, I also executed the command to adapt the /etc/hosts. However, I think that the order of minikube and $(minikube ip) in the command must be changed. Else, the ip of the hostname cannot be resolved.