### PR TITLE
Add Tavern based helm chart tests

### DIFF
--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -69,3 +69,10 @@ jobs:
       - name: Run chart-testing (install)
         run: ct install --charts charts/registry --config charts/chart-testing-config.yaml
         if: steps.list-changed.outputs.changed == 'true'
+
+      - name: Upload test report
+        uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: aas-registry-e2e-test-report
+          path: /opt/report.html

--- a/charts/registry/Chart.yaml
+++ b/charts/registry/Chart.yaml
@@ -23,7 +23,7 @@ name: registry
 description: Tractus-X Digital Twin Registry Helm Chart
 
 type: application
-version: 0.3.2
+version: 0.3.3
 appVersion: 0.3.2-M1
 
 dependencies:

--- a/charts/registry/templates/tests/test-connection.yaml
+++ b/charts/registry/templates/tests/test-connection.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "test-script-pod"
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: test-container
+      image: python:3.8-slim
+      workingDir: /tests
+      command: ['./test-script.sh']
+      volumeMounts:
+        - name: test-script
+          mountPath: /tests
+        - name: test-output
+          mountPath: /tests/output
+      env:
+        - name: CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name: test-credentials
+              key: clientId
+        - name: CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: test-credentials
+              key: clientSecret
+        - name: AAS_REGISTRY_API_URL
+          valueFrom:
+            secretKeyRef:
+              name: test-credentials
+              key: aasRegistryUrl
+        - name: AUTH_SERVER_TOKEN_URL
+          valueFrom:
+            secretKeyRef:
+              name: test-credentials
+              key: authServerTokenUrl
+  volumes:
+    - name: test-script
+      configMap:
+        name: test-script
+        defaultMode: 0777
+    - name: test-output
+      hostPath:
+        path: /opt
+        type: Directory
+
+  restartPolicy: Never

--- a/charts/registry/templates/tests/test-credentials.yaml
+++ b/charts/registry/templates/tests/test-credentials.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: test-credentials
+type: Opaque
+data:
+  clientId: {{ "default-client" | b64enc }}
+  clientSecret: {{ "wJcfhf5uXynRcAHy5Ua9KAwM4EhsFvC1" | b64enc }}
+  authServerTokenUrl: {{ "http://registry-keycloak/realms/default-realm/protocol/openid-connect/token" | b64enc }}
+  aasRegistryUrl: {{ printf "http://cx-%s-registry-svc:8080" .Release.Name | b64enc }}

--- a/charts/registry/templates/tests/test-script-configmap.yaml
+++ b/charts/registry/templates/tests/test-script-configmap.yaml
@@ -1,0 +1,153 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: test-script
+data:
+  test-script.sh: |
+    #!/bin/sh
+    pip install -r requirements.txt
+    py.test . -vv --html=./output/report.html --self-contained-html
+  requirements.txt: |
+    pytest==7.1.2
+    tavern==1.23.3
+    pytest-html==3.1.1
+  common.yaml: |
+    ---
+    name: Common variable definitions
+    description:
+      Contains common variable definitions.
+
+    variables:
+      aas_registry_api_url: "{tavern.env_vars.AAS_REGISTRY_API_URL}"
+  stage_auth.yaml: |
+    ---
+    name: Authentication stage
+    description:
+      Reusable test stage for authentication
+
+    variables:
+      auth:
+        client_id: "{tavern.env_vars.CLIENT_ID}"
+        client_secret: "{tavern.env_vars.CLIENT_SECRET}"
+        auth_server_token_url: "{tavern.env_vars.AUTH_SERVER_TOKEN_URL}"
+
+    stages:
+      - id: request_auth_token
+        name: Request token
+        request:
+          url: "{auth.auth_server_token_url:s}"
+          headers:
+            Accept: "*/*"
+            Content-Type: "application/x-www-form-urlencoded"
+          data:
+            grant_type: "client_credentials"
+            client_id: "{auth.client_id:s}"
+            client_secret: "{auth.client_secret:s}"
+          method: POST
+        response:
+          status_code: 200
+          headers:
+            content-type: application/json
+          save:
+            json:
+              access_token: access_token
+  test_api.tavern.yaml: |
+    ---
+    test_name: Test APIs are protected with authentication
+
+    includes:
+      - !include common.yaml
+      - !include stage_auth.yaml
+
+    stages:
+      - name: Test get shell descriptors without access token
+        request:
+          url: "{aas_registry_api_url:s}/registry/shell-descriptors"
+          method: GET
+        response:
+          status_code: 401
+
+      - type: ref
+        id: request_auth_token
+
+      - name: Authenticated request
+        request:
+          url: "{aas_registry_api_url:s}/registry/shell-descriptors"
+          method: GET
+          headers:
+            Content-Type: application/json
+            Authorization: "Bearer {access_token}"
+        response:
+          status_code: 200
+          headers:
+            content-type: application/json
+
+    ---
+    test_name: Test create, read, update and delete of a shell descriptor
+
+    includes:
+      - !include common.yaml
+      - !include stage_auth.yaml
+
+    stages:
+      - type: ref
+        id: request_auth_token
+
+      - name: Create shell descriptor expect success
+        request:
+          url: "{aas_registry_api_url:s}/registry/shell-descriptors"
+          method: POST
+          headers:
+            Content-Type: application/json
+            Authorization: "Bearer {access_token}"
+          json: 
+            identification: !uuid
+            idShort: twin of a break (Testing)
+        response:
+          status_code: 201
+          headers:
+            content-type: application/json
+          save:
+            json:
+              returned_identification: identification
+        
+      - name: Get shell descriptor by identification
+        request:
+          url: "{aas_registry_api_url:s}/registry/shell-descriptors/{returned_identification:s}"
+          method: GET
+          headers:
+            Content-Type: application/json
+            Authorization: "Bearer {access_token}"
+        response:
+          status_code: 200
+          headers:
+            content-type: application/json
+          json: 
+            identification: "{returned_identification:s}"
+            idShort: twin of a break (Testing)
+            description: []
+            specificAssetIds: []
+            submodelDescriptors: []
+
+      - name: Update shell descriptor by identification
+        request:
+          url: "{aas_registry_api_url:s}/registry/shell-descriptors/{returned_identification:s}"
+          method: PUT
+          headers:
+            Content-Type: application/json
+            Authorization: "Bearer {access_token}"
+          json: 
+            identification: "{returned_identification:s}"
+            idShort: twin of a break (Testing Update)
+        response:
+          status_code: 204
+
+      - name: Delete shell descriptor by identification
+        request:
+          url: "{aas_registry_api_url:s}/registry/shell-descriptors/{returned_identification:s}"
+          method: DELETE
+          headers:
+            Content-Type: application/json
+            Authorization: "Bearer {access_token}"
+        response:
+          status_code: 204


### PR DESCRIPTION
This PR includes tavern based helm chart tests that are executed, whenever the Helm chart changes. A test report should be uploaded as a GitHub Actions artifact.