### PR TITLE
Implement filter on getting Digital Twin based on BPN number

### DIFF
--- a/backend/src/main/java/org/eclipse/tractusx/semantics/registry/service/ShellService.java
+++ b/backend/src/main/java/org/eclipse/tractusx/semantics/registry/service/ShellService.java
@@ -111,7 +111,7 @@ public class ShellService {
             return shellIdentifiers;
         }
         return shellIdentifiers.stream()
-                .filter(shellIdentifier -> shellIdentifier.getExternalSubjectId() == null ||
+                .filter(shellIdentifier -> shellIdentifier.getExternalSubjectId() != null &&
                         shellIdentifier.getExternalSubjectId().equals(requestingTenantId)).collect(Collectors.toSet());
     }
 

--- a/backend/src/test/java/org/eclipse/tractusx/semantics/registry/AssetAdministrationShellApiSecurityTest.java
+++ b/backend/src/test/java/org/eclipse/tractusx/semantics/registry/AssetAdministrationShellApiSecurityTest.java
@@ -614,7 +614,8 @@ public class AssetAdministrationShellApiSecurityTest extends AbstractAssetAdmini
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.items").exists())
                     .andExpect(jsonPath("$.items[*].identification", hasItem(getId(shellPayload))))
-                    .andExpect(jsonPath("$.items[*].specificAssetIds[*].value", hasItems(tenantTwoAssetIdValue, withoutTenantAssetIdValue)))
+                    .andExpect(jsonPath("$.items[*].specificAssetIds[*].value", hasItems(tenantTwoAssetIdValue)))
+                    .andExpect(jsonPath("$.items[*].specificAssetIds[*].value", not(hasItem(withoutTenantAssetIdValue))))
                     .andExpect(jsonPath("$.items[*].specificAssetIds[*].value", not(hasItem(tenantThreeAssetIdValue))));
         }
 
@@ -652,7 +653,8 @@ public class AssetAdministrationShellApiSecurityTest extends AbstractAssetAdmini
                     .andDo(MockMvcResultHandlers.print())
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.identification", equalTo(shellId)))
-                    .andExpect(jsonPath("$.specificAssetIds[*].value", hasItems(tenantTwoAssetIdValue, withoutTenantAssetIdValue)))
+                    .andExpect(jsonPath("$.specificAssetIds[*].value", hasItems(tenantTwoAssetIdValue)))
+                    .andExpect(jsonPath("$.specificAssetIds[*].value", not(hasItem(withoutTenantAssetIdValue))))
                     .andExpect(jsonPath("$.specificAssetIds[*].value", not(hasItem(tenantThreeAssetIdValue))));
         }
 
@@ -694,7 +696,8 @@ public class AssetAdministrationShellApiSecurityTest extends AbstractAssetAdmini
                     .andDo(MockMvcResultHandlers.print())
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.items[*].identification", hasItem(shellId)))
-                    .andExpect(jsonPath("$.items[*].specificAssetIds[*].value", hasItems(tenantTwoAssetIdValue, withoutTenantAssetIdValue)))
+                    .andExpect(jsonPath("$.items[*].specificAssetIds[*].value", hasItems(tenantTwoAssetIdValue)))
+                    .andExpect(jsonPath("$.items[*].specificAssetIds[*].value", not(hasItem(withoutTenantAssetIdValue))))
                     .andExpect(jsonPath("$.items[*].specificAssetIds[*].value", not(hasItem(tenantThreeAssetIdValue))));
         }
 
@@ -745,7 +748,8 @@ public class AssetAdministrationShellApiSecurityTest extends AbstractAssetAdmini
                     )
                     .andDo(MockMvcResultHandlers.print())
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$[*].value", hasItems(tenantTwoAssetIdValue, withoutTenantAssetIdValue)))
+                    .andExpect(jsonPath("$[*].value", hasItems(tenantTwoAssetIdValue)))
+                    .andExpect(jsonPath("$[*].value", not(hasItem(withoutTenantAssetIdValue))))
                     .andExpect(jsonPath("$[*].value", not(hasItem(tenantThreeAssetIdValue))));
         }
 


### PR DESCRIPTION
## Description
Adjust implementation to return only specificAssetIds for consumer (not owner of twins) which matched the externalSubjectIds