### PR TITLE
DDTR-Implement filter on getting Digital Twin based on BPN number

### DIFF
--- a/backend/src/main/java/org/eclipse/tractusx/semantics/registry/service/ShellService.java
+++ b/backend/src/main/java/org/eclipse/tractusx/semantics/registry/service/ShellService.java
@@ -104,7 +104,7 @@ public class ShellService {
             return shellIdentifiers;
         }
         return shellIdentifiers.stream()
-                .filter(shellIdentifier -> shellIdentifier.getExternalSubjectId() == null ||
+                .filter(shellIdentifier -> shellIdentifier.getExternalSubjectId() != null &&
                         shellIdentifier.getExternalSubjectId().equals(tenantId)).collect(Collectors.toSet());
     }
 

--- a/backend/src/test/java/org/eclipse/tractusx/semantics/registry/AssetAdministrationShellApiSecurityTest.java
+++ b/backend/src/test/java/org/eclipse/tractusx/semantics/registry/AssetAdministrationShellApiSecurityTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 
@@ -651,16 +652,17 @@ public class AssetAdministrationShellApiSecurityTest extends AbstractAssetAdmini
             // test with tenant two
             mvc.perform(
                             MockMvcRequestBuilders
-                                    .get(SHELL_BASE_PATH)
+                                    .get(SINGLE_SHELL_BASE_PATH, shellPayload.getId())
                                     .queryParam("pageSize", "100")
                                     .accept(MediaType.APPLICATION_JSON)
                                     .with(jwtTokenFactory.tenantTwo().allRoles())
                     )
                     .andDo(MockMvcResultHandlers.print())
                     .andExpect(status().isOk())
-                    .andExpect(jsonPath("$.result").exists())
-                    .andExpect(jsonPath("$.result[*].specificAssetIds[*].value", hasItems("identifier1ValueExample", "identifier2ValueExample")))
-                    .andExpect(jsonPath("$.result[*].specificAssetIds[*].value", not(hasItem("tenantThreeAssetIdValue"))));
+                    .andExpect(jsonPath("$.specificAssetIds[*].value", hasSize( 0 )))
+                    .andExpect(jsonPath("$.specificAssetIds[*].value", not(hasItem("identifier1ValueExample"))))
+                    .andExpect(jsonPath("$.specificAssetIds[*].value", not(hasItem("identifier2ValueExample"))))
+                    .andExpect(jsonPath("$.specificAssetIds[*].value", not(hasItem("tenantThreeAssetIdValue"))));
         }
 
         @Test
@@ -700,7 +702,8 @@ public class AssetAdministrationShellApiSecurityTest extends AbstractAssetAdmini
                     .andDo(MockMvcResultHandlers.print())
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.id", equalTo(shellId)))
-                    .andExpect(jsonPath("$.specificAssetIds[*].value", hasItems("tenantTwoAssetIdValue", "withoutTenantAssetIdValue")))
+                    .andExpect(jsonPath("$.specificAssetIds[*].value", hasItems("tenantTwoAssetIdValue")))
+                    .andExpect(jsonPath("$.specificAssetIds[*].value", not(hasItem("withoutTenantAssetIdValue"))))
                     .andExpect(jsonPath("$.specificAssetIds[*].value", not(hasItem("tenantThreeAssetIdValue"))));
         }
 

--- a/backend/src/test/java/org/eclipse/tractusx/semantics/registry/JwtTokenFactory.java
+++ b/backend/src/test/java/org/eclipse/tractusx/semantics/registry/JwtTokenFactory.java
@@ -39,7 +39,7 @@ import static org.springframework.security.test.web.servlet.request.SecurityMock
 
 public class JwtTokenFactory {
 
-    private static final String TENANT_ONE = "TENANT_ONE";
+    private static final String TENANT_ONE = "TENANT_OWNER";
     private static final String TENANT_TWO = "TENANT_TWO";
     private static final String TENANT_THREE = "TENANT_THREE";
 

--- a/backend/src/test/resources/application-test.yml
+++ b/backend/src/test/resources/application-test.yml
@@ -39,7 +39,7 @@ spring:
 
 registry:
   idm:
-    owning-tenant-id: TENANT_ONE
+    owning-tenant-id: TENANT_OWNER
 
 logging:
   level:


### PR DESCRIPTION
## Description
Adjust implementation to return only specificAssetIds for consumer (not owner of twins) which matched the externalSubjectIds