### PR TITLE
fix: Disable creation of keycloak-database secret if keycloak is disabled

### DIFF
--- a/charts/registry/Chart.yaml
+++ b/charts/registry/Chart.yaml
@@ -23,7 +23,7 @@ name: registry
 description: Tractus-X Digital Twin Registry Helm Chart
 
 type: application
-version: 0.3.12
+version: 0.3.13
 appVersion: 0.3.11-M1
 
 dependencies:

--- a/charts/registry/templates/keycloak/database-credentials.yaml
+++ b/charts/registry/templates/keycloak/database-credentials.yaml
@@ -1,4 +1,4 @@
-{{ if not .Values.keycloak.postgresql.enabled }}
+{{ if and .Values.enableKeycloak (not .Values.keycloak.postgresql.enabled) }}
 ###############################################################
 # Copyright (c) 2023 Robert Bosch Manufacturing Solutions GmbH
 # Copyright (c) 2023 Contributors to the Eclipse Foundation


### PR DESCRIPTION
## Description

This change disables the creation of the keycloak-database secret if keycloak is disabled at all

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up to date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] Copyright and license header are present on all affected files

### Additional information

- To request a review, check out [who's involved](https://projects.eclipse.org/projects/automotive.tractusx/who) to see a list of contributors and committers
- Use the [mailing list](https://accounts.eclipse.org/mailing-list/tractusx-dev) if you are unsure, who to contact, or if want to engage in a general discussion
- Check out our guide on [how to contribute](https://eclipse-tractusx.github.io/docs/oss/how-to-contribute)
- Check out our [Release Guidelines](https://eclipse-tractusx.github.io/docs/release)
- Check out the [Eclipse Foundation contribution guidelines](https://www.eclipse.org/projects/handbook/#contributing)
