### PR TITLE
Missing legal information header added

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -1,3 +1,22 @@
+###############################################################
+# Copyright (c) 2021, 2023 Robert Bosch Manufacturing Solutions GmbH
+# Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+###############################################################
 name: Release - Helm Charts
 
 on:

--- a/.github/workflows/kics.yml
+++ b/.github/workflows/kics.yml
@@ -1,3 +1,22 @@
+###############################################################
+# Copyright (c) 2021, 2023 Robert Bosch Manufacturing Solutions GmbH
+# Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+###############################################################
 name: "KICS"
 
 on:

--- a/.tractusx
+++ b/.tractusx
@@ -1,3 +1,23 @@
+/********************************************************************************
+ * Copyright (c) 2021-2023 Robert Bosch Manufacturing Solutions GmbH
+ * Copyright (c) 2021-2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
 product: "Digital Twin Registry"
 leadingRepository: "https://github.com/eclipse-tractusx/sldt-digital-twin-registry"
 repositories:

--- a/backend/src/main/resources/catena-template.css
+++ b/backend/src/main/resources/catena-template.css
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2021, 2023 Robert Bosch Manufacturing Solutions GmbH
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
 h1 {
     color: black;
     font-size: 2rem;

--- a/backend/src/test/java/org/eclipse/tractusx/semantics/registry/HealthCheckTest.java
+++ b/backend/src/test/java/org/eclipse/tractusx/semantics/registry/HealthCheckTest.java
@@ -1,3 +1,22 @@
+/********************************************************************************
+ * Copyright (c) 2021, 2023 Robert Bosch Manufacturing Solutions GmbH
+ * Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
 package org.eclipse.tractusx.semantics.registry;
 
 import static org.hamcrest.Matchers.is;

--- a/charts/registry/Chart.yaml
+++ b/charts/registry/Chart.yaml
@@ -26,7 +26,7 @@ sources:
   - https://github.com/eclipse-tractusx/sldt-digital-twin-registry
 
 type: application
-version: 0.3.20
+version: 0.3.21
 appVersion: 0.3.13-M1
 
 dependencies:

--- a/charts/registry/templates/tests/test-connection.yaml
+++ b/charts/registry/templates/tests/test-connection.yaml
@@ -1,3 +1,22 @@
+###############################################################
+# Copyright (c) 2021, 2023 Robert Bosch Manufacturing Solutions GmbH
+# Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+###############################################################
 apiVersion: v1
 kind: Pod
 metadata:

--- a/charts/registry/templates/tests/test-credentials.yaml
+++ b/charts/registry/templates/tests/test-credentials.yaml
@@ -1,3 +1,22 @@
+###############################################################
+# Copyright (c) 2021, 2023 Robert Bosch Manufacturing Solutions GmbH
+# Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+###############################################################
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/registry/templates/tests/test-script-configmap.yaml
+++ b/charts/registry/templates/tests/test-script-configmap.yaml
@@ -1,3 +1,22 @@
+###############################################################
+# Copyright (c) 2021, 2023 Robert Bosch Manufacturing Solutions GmbH
+# Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+###############################################################
 kind: ConfigMap
 apiVersion: v1
 metadata:

--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright (c) 2021-2022 T-Systems International GmbH
+    Copyright (c) 2021-2022 Contributors to the Eclipse Foundation
 
     See the AUTHORS file(s) distributed with this work for additional
     information regarding authorship.


### PR DESCRIPTION
## Description
Missing legal information header:
.github/workflows/helm-release.yml
.github/workflows/kics.yml
.tractusx
backend/src/main/resources/catena-template.css
backend/src/test/java/org/eclipse/tractusx/semantics/registry/HealthCheckTest.java
charts/registry/templates/tests/test-connection.yaml
charts/registry/templates/tests/test-credentials.yaml
charts/registry/templates/tests/test-script-configmap.yaml
pom.xml