### PR TITLE
Bugfix/return global asset id for fullaccess

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.14-rc1
+### Added
+
+## fixed
+- Bugfix: GlobalAssetId was not shown in the shell response. This bug is fixed. GlobalAssetId is shown, if the consumer has full access to the shell.
+
 ## 0.3.13-M1
 ### Added
 - In this version the models have been adjusted to new version AAS 3.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.3.14-rc1
+## 0.3.14-M1
 ### Added
 
 ## fixed

--- a/backend/src/main/java/org/eclipse/tractusx/semantics/registry/repository/ShellRepository.java
+++ b/backend/src/main/java/org/eclipse/tractusx/semantics/registry/repository/ShellRepository.java
@@ -76,7 +76,7 @@ public interface ShellRepository extends JpaRepository<Shell, UUID>, JpaSpecific
     @Query( value = "select s.id_external from shell s where s.id in (" +
           "select si.fk_shell_id from shell_identifier si " +
           "where concat(si.namespace,si.identifier) in (:keyValueCombinations) " +
-          "and (:tenantId = :owningTenantId or exists (" +
+          "and (:tenantId = :owningTenantId or si.namespace= :globalAssetId or exists (" +
                 "Select sider.ref_key_value from SHELL_IDENTIFIER_EXTERNAL_SUBJECT_REFERENCE_KEY sider where (sider.ref_key_value = :tenantId or (sider.ref_key_value = :publicWildcardPrefix and si.namespace in (:publicWildcardAllowedTypes) )) and sider.FK_SI_EXTERNAL_SUBJECT_REFERENCE_ID="+
           "(select sies.id from SHELL_IDENTIFIER_EXTERNAL_SUBJECT_REFERENCE sies where sies.FK_SHELL_IDENTIFIER_EXTERNAL_SUBJECT_ID=si.id)"+
           ")) group by si.fk_shell_id " +
@@ -87,7 +87,8 @@ public interface ShellRepository extends JpaRepository<Shell, UUID>, JpaSpecific
                                                    @Param("tenantId") String tenantId,
                                                    @Param ("publicWildcardPrefix") String publicWildcardPrefix,
                                                    @Param ("publicWildcardAllowedTypes") List<String> publicWildcardAllowedTypes,
-                                                   @Param("owningTenantId") String owningTenantId);
+                                                   @Param("owningTenantId") String owningTenantId,
+                                                   @Param("globalAssetId") String globalAssetId);
 
     /**
      * Returns external shell ids for the given keyValueCombinations.

--- a/backend/src/main/java/org/eclipse/tractusx/semantics/registry/service/ShellAccessHandler.java
+++ b/backend/src/main/java/org/eclipse/tractusx/semantics/registry/service/ShellAccessHandler.java
@@ -71,8 +71,13 @@ public class ShellAccessHandler {
       );
 
       if ( hasOnlyPublicAccess ) {
+         // Filter out globalAssetId from specificAssetId. TODO: implement to save globalAssetId in separate database column
+         // GlobalAssetId is set via mapper. In case of only read access, no globalAssetId should be shown.
+         Set<ShellIdentifier> filteredIdentifiersWithNoGlobalAssetId = filteredIdentifiers.stream().filter(
+               shellIdentifier -> !shellIdentifier.getKey().equals( ShellIdentifier.GLOBAL_ASSET_ID_KEY ) )
+               .collect( Collectors.toSet() );
          return new Shell()
-               .withIdentifiers( filteredIdentifiers )
+               .withIdentifiers(filteredIdentifiersWithNoGlobalAssetId)
                .withSubmodels( shell.getSubmodels() )
                .withIdExternal( shell.getIdExternal() )
                .withId( shell.getId() )
@@ -89,6 +94,10 @@ public class ShellAccessHandler {
 
       Set<ShellIdentifier> externalSubjectIdSet = new HashSet<>();
       for ( ShellIdentifier identifier : shellIdentifiers ) {
+         // Check if specificAssetId is globalAssetId -> TODO: implement to save globalAssetId in separate database column
+         if(identifier.getKey().equals( ShellIdentifier.GLOBAL_ASSET_ID_KEY )){
+            externalSubjectIdSet.add( identifier );
+         }
          if ( identifier.getExternalSubjectId() != null ) {
             Set<ShellIdentifierExternalSubjectReferenceKey> optionalReferenceKey =
                   identifier.getExternalSubjectId().getKeys().stream().filter( shellIdentifierExternalSubjectReferenceKey ->

--- a/backend/src/main/java/org/eclipse/tractusx/semantics/registry/service/ShellService.java
+++ b/backend/src/main/java/org/eclipse/tractusx/semantics/registry/service/ShellService.java
@@ -198,7 +198,7 @@ public class ShellService {
       List<String> keyValueCombinations = shellIdentifiers.stream().map( shellIdentifier -> shellIdentifier.getKey() + shellIdentifier.getValue() ).toList();
 
       List<String> queryResult = shellRepository.findExternalShellIdsByIdentifiersByExactMatch( keyValueCombinations,
-            keyValueCombinations.size(), externalSubjectId, externalSubjectIdWildcardPrefix, externalSubjectIdWildcardAllowedTypes, owningTenantId );
+            keyValueCombinations.size(), externalSubjectId, externalSubjectIdWildcardPrefix, externalSubjectIdWildcardAllowedTypes, owningTenantId, ShellIdentifier.GLOBAL_ASSET_ID_KEY );
       pageSize = getPageSize( pageSize );
 
       int startIndex = getCursorDecoded( cursor, queryResult );

--- a/backend/src/test/java/org/eclipse/tractusx/semantics/registry/AssetAdministrationShellApiSecurityTest.java
+++ b/backend/src/test/java/org/eclipse/tractusx/semantics/registry/AssetAdministrationShellApiSecurityTest.java
@@ -1173,7 +1173,8 @@ public class AssetAdministrationShellApiSecurityTest extends AbstractAssetAdmini
                 .andDo(MockMvcResultHandlers.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.description[*]").isNotEmpty())
-                .andExpect(jsonPath("$.idShort",is(shellPayload.getIdShort())));
+                .andExpect(jsonPath("$.idShort",is(shellPayload.getIdShort())))
+                .andExpect(jsonPath("$.globalAssetId",is(shellPayload.getGlobalAssetId())));
 
           // Request with TenantId (TENANT_TWO) returns no shell, because the shell not includes the externalSubjectId of Tenant_two as specificId
           mvc.perform(
@@ -1218,6 +1219,7 @@ public class AssetAdministrationShellApiSecurityTest extends AbstractAssetAdmini
                 .andDo(MockMvcResultHandlers.print())
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.description[*]").isNotEmpty())
+                .andExpect(jsonPath("$.globalAssetId",is(shellPayload.getGlobalAssetId())))
                 .andExpect(jsonPath("$.idShort",is(shellPayload.getIdShort())))
                 .andExpect(jsonPath("$.id",is( shellPayload.getId() )))
                 .andExpect(jsonPath("$.submodelDescriptors[*]").exists())
@@ -1236,6 +1238,7 @@ public class AssetAdministrationShellApiSecurityTest extends AbstractAssetAdmini
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.description[*]").doesNotExist())
                 .andExpect(jsonPath("$.idShort").doesNotExist())
+                .andExpect(jsonPath("$.globalAssetId").doesNotExist())
                 .andExpect(jsonPath("$.id",is( shellPayload.getId() )))
                 .andExpect(jsonPath("$.submodelDescriptors[*]").exists())
                 .andExpect(jsonPath("$.specificAssetIds[*]").exists());


### PR DESCRIPTION
## Description
This bugifx PR includes the fix for globalAssetId. 
If consumer has full access to the shell, the globalAssetId is returned in the shell response.