### PR TITLE
legal header information corrected

### DIFF
--- a/.github/actions/generate-dependencies-notice/action.yml
+++ b/.github/actions/generate-dependencies-notice/action.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Copyright (c) 2023 Robert Bosch Manufacturing Solutions GmbH
+# Copyright (c) 2023 Robert Bosch Manufacturing Solutions GmbH
 # Copyright (c) 2023 Contributors to the Eclipse Foundation
 
 # See the NOTICE file(s) distributed with this work for additional

--- a/.github/actions/generate-dependencies-notice/index.js
+++ b/.github/actions/generate-dependencies-notice/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright (c) 2023 Copyright (c) 2023 Robert Bosch Manufacturing Solutions GmbH
+Copyright (c) 2023 Robert Bosch Manufacturing Solutions GmbH
 Copyright (c) 2023 Contributors to the Eclipse Foundation
 
 See the NOTICE file(s) distributed with this work for additional

--- a/.github/workflows/build-snapshot.yml
+++ b/.github/workflows/build-snapshot.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2022 Copyright (c) 2021-2022 Robert Bosch Manufacturing Solutions GmbH
+# Copyright (c) 2021-2022 Robert Bosch Manufacturing Solutions GmbH
 # Copyright (c) 2021-2022 Contributors to the Eclipse Foundation
 
 # See the NOTICE file(s) distributed with this work for additional

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2022 Copyright (c) 2021-2022 Robert Bosch Manufacturing Solutions GmbH
+# Copyright (c) 2021-2022 Robert Bosch Manufacturing Solutions GmbH
 # Copyright (c) 2021-2022 Contributors to the Eclipse Foundation
 
 # See the NOTICE file(s) distributed with this work for additional

--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Copyright (c) 2023 Robert Bosch Manufacturing Solutions GmbH
+# Copyright (c) 2023 Robert Bosch Manufacturing Solutions GmbH
 # Copyright (c) 2023 Contributors to the Eclipse Foundation
 
 # See the NOTICE file(s) distributed with this work for additional

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2022 Copyright (c) 2021-2022 Robert Bosch Manufacturing Solutions GmbH
+# Copyright (c) 2021-2022 Robert Bosch Manufacturing Solutions GmbH
 # Copyright (c) 2021-2022 Contributors to the Eclipse Foundation
 
 # See the NOTICE file(s) distributed with this work for additional

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2021-2022 Copyright (c) 2021-2022 Robert Bosch Manufacturing Solutions GmbH
+# Copyright (c) 2021-2022 Robert Bosch Manufacturing Solutions GmbH
 # Copyright (c) 2021-2022 Contributors to the Eclipse Foundation
 
 # See the NOTICE file(s) distributed with this work for additional

--- a/.github/workflows/veracode.yaml
+++ b/.github/workflows/veracode.yaml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023 Copyright (c) 2021-2022 Robert Bosch Manufacturing Solutions GmbH
+# Copyright (c) 2023 Robert Bosch Manufacturing Solutions GmbH
 # Copyright (c) 2023 Contributors to the Eclipse Foundation
 
 # See the NOTICE file(s) distributed with this work for additional

--- a/backend/src/main/java/org/eclipse/tractusx/semantics/registry/service/ShellAccessHandler.java
+++ b/backend/src/main/java/org/eclipse/tractusx/semantics/registry/service/ShellAccessHandler.java
@@ -1,18 +1,3 @@
-package org.eclipse.tractusx.semantics.registry.service;
-
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-
-import org.eclipse.tractusx.semantics.RegistryProperties;
-import org.eclipse.tractusx.semantics.registry.model.Shell;
-import org.eclipse.tractusx.semantics.registry.model.ShellIdentifier;
-import org.eclipse.tractusx.semantics.registry.model.ShellIdentifierExternalSubjectReferenceKey;
-import org.springframework.stereotype.Service;
-
-import lombok.extern.slf4j.Slf4j;
-
 /********************************************************************************
  * Copyright (c) 2021-2023 Robert Bosch Manufacturing Solutions GmbH
  * Copyright (c) 2021-2023 Contributors to the Eclipse Foundation
@@ -32,6 +17,22 @@ import lombok.extern.slf4j.Slf4j;
  *
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
+
+package org.eclipse.tractusx.semantics.registry.service;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.eclipse.tractusx.semantics.RegistryProperties;
+import org.eclipse.tractusx.semantics.registry.model.Shell;
+import org.eclipse.tractusx.semantics.registry.model.ShellIdentifier;
+import org.eclipse.tractusx.semantics.registry.model.ShellIdentifierExternalSubjectReferenceKey;
+import org.springframework.stereotype.Service;
+
+import lombok.extern.slf4j.Slf4j;
+
 @Slf4j
 @Service
 public class ShellAccessHandler {


### PR DESCRIPTION
## Description
Legal information header has been corrected:
- the legal information header will start at line 1 in each class
- double copyright expression like "Copyright (c) 2023 Copyright (c) 2023" have been corrected
