### PR TITLE
fix: Properly template the default psql service name

### DIFF
--- a/charts/registry/Chart.yaml
+++ b/charts/registry/Chart.yaml
@@ -26,7 +26,7 @@ sources:
   - https://github.com/eclipse-tractusx/sldt-digital-twin-registry
 
 type: application
-version: 0.3.27
+version: 0.3.28
 appVersion: 0.3.19
 
 dependencies:

--- a/charts/registry/templates/registry/registry-secret.yaml
+++ b/charts/registry/templates/registry/registry-secret.yaml
@@ -27,7 +27,7 @@ metadata:
 type: Opaque
 data:
   {{- if .Values.enablePostgres }}
-  SPRING_DATASOURCE_URL: {{ printf "jdbc:postgresql://%s-postgresql:%v/%s" .Release.Name .Values.postgresql.service.ports.postgresql .Values.postgresql.auth.database | b64enc }}
+  SPRING_DATASOURCE_URL: {{ printf "jdbc:postgresql://%s:%v/%s" (include "postgresql.v1.primary.fullname" .Subcharts.postgresql ) .Values.postgresql.service.ports.postgresql .Values.postgresql.auth.database | b64enc }}
   SPRING_DATASOURCE_USERNAME: {{ .Values.postgresql.auth.username | b64enc }}
   SPRING_DATASOURCE_PASSWORD: {{ .Values.postgresql.auth.password | b64enc }}
   {{- else }}


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->
Currently the postgresql service name is templated as .Release.Name -postgresql, which breaks, if e.g. postgresql.nameOverride is used.
This is a common scenario, if using a chart as subchart and necessary to avoid collisions with e.g. other postgresqls.

Instead the template should use the same logic as the postgresql service itself.


### Compatibility with Helm 3.2.0+
I noticed, the .Subcharts context is only available on Helm 3.7+, but the generated Readme is out of sync, therefore I wasn't sure if the "Helm 3.2.0+" Prerequisite is still up to date.
Otherwise I would suggest to expose the jdbcUrl in the values similar to the tractusx-edc chart:
![image](https://github.com/eclipse-tractusx/sldt-digital-twin-registry/assets/124401943/178240fe-68ea-4a3e-aabf-e1951bbf115f)

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
