### PR TITLE
update column 'Sub_Protocol_Body' to length of 2048

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.3.21
+### Added
+- Length for Column "SUB_PROTOCOL_BODY" has been extended to 2048.
+## fixed
+
+
 ## 0.3.20
 ### Added
 

--- a/backend/src/main/resources/db/changelog/db.changelog-v3.yaml
+++ b/backend/src/main/resources/db/changelog/db.changelog-v3.yaml
@@ -142,3 +142,11 @@ databaseChangeLog:
             columns:
               - column:
                   name: NAMESPACE
+  - changeSet:
+      id: 28112023-01
+      author: slindner
+      changes:
+        - modifyDataType:
+            tableName: SUBMODEL_ENDPOINT
+            columnName: SUB_PROTOCOL_BODY
+            newDataType: NVARCHAR(2048)

--- a/backend/src/main/resources/static/aas-registry-openapi.yaml
+++ b/backend/src/main/resources/static/aas-registry-openapi.yaml
@@ -1396,7 +1396,7 @@ components:
           maxLength: 128
           type: string
         subprotocolBody:
-          maxLength: 2000
+          maxLength: 2048
           type: string
         subprotocolBodyEncoding:
           maxLength: 128


### PR DESCRIPTION
## Description
Increased the field length of column "Sub_Protocol_Body" from table "SUBMODEL_ENDPOINTSUBMODEL_ENDPOINT" to 2048. Also the openapi.yml has been adjusted to this value. 