### PR TITLE
fix: Runtime issue of ShellRepository.findByIdExternalAndExternalSubjectId()

### DIFF
--- a/backend/src/main/java/org/eclipse/tractusx/semantics/registry/repository/ShellRepository.java
+++ b/backend/src/main/java/org/eclipse/tractusx/semantics/registry/repository/ShellRepository.java
@@ -41,8 +41,8 @@ public interface ShellRepository extends JpaRepository<Shell, UUID>, JpaSpecific
    @Query( value = "select * from shell s " +
          "where s.id_external = :idExternal and (" +
          ":tenantId = :owningTenantId " +
-         "or s.id in (" +
-            "select si.fk_shell_id from shell_identifier si where exists (" +
+         "or exists (" +
+            "select si.fk_shell_id from shell_identifier si where si.fk_shell_id = s.id and exists (" +
             "select sider.ref_key_value from SHELL_IDENTIFIER_EXTERNAL_SUBJECT_REFERENCE_KEY sider " +
             "where (sider.ref_key_value = :tenantId " +
             "or (sider.ref_key_value = :publicWildcardPrefix and si.namespace in (:publicWildcardAllowedTypes) )) " +


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->
Issue:
With a growing number of shells registered ShellRepository.findByIdExternalAndExternalSubjectId() has an exponentially growing run time when accessed by a different one than the owning tenant id.

Solution:
The fix replaces the expensive IN statement in the WHERE clause of the backing SQL command by a much more cheaper EXISTS statement.
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
