### PR TITLE
Fix github action: publish-image-registry

### DIFF
--- a/.github/workflows/publish-image-registry.yml
+++ b/.github/workflows/publish-image-registry.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           java-version: 17
       - name: execute-maven-deps
-        working-directory: ./backend
+        working-directory: ./
         run: mvn verify dependency:list -DskipTests -Dmaven.javadoc.skip=true -DappendOutput=false -DoutputFile=maven.deps -DincludeScope=compile
       - name: install dependencies
         working-directory: ./.github/actions/generate-dependencies-notice


### PR DESCRIPTION
## Description
Fix github action: publish-image-registry
Build maven.deps from root project instead of ./backend