### PR TITLE
feat: Extend DTR APIs for Access management - Clean-up

### DIFF
--- a/backend/src/main/java/org/eclipse/tractusx/semantics/registry/repository/ShellIdentifierRepository.java
+++ b/backend/src/main/java/org/eclipse/tractusx/semantics/registry/repository/ShellIdentifierRepository.java
@@ -29,6 +29,7 @@ import org.eclipse.tractusx.semantics.registry.model.projection.ShellIdentifierM
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ShellIdentifierRepository extends JpaRepository<ShellIdentifier, UUID> {
 
@@ -50,6 +51,52 @@ public interface ShellIdentifierRepository extends JpaRepository<ShellIdentifier
                     GROUP BY filtersid.shellId.id
                     HAVING COUNT(*) = :keyValueCombinationsSize
                 )
-         """)
+         """ )
    List<ShellIdentifierMinimal> findMinimalShellIdsBySpecificAssetIds( List<String> keyValueCombinations, int keyValueCombinationsSize );
+
+   /**
+    * Returns external shell ids for the given keyValueCombinations.
+    * External shell ids matching the conditions below are returned:
+    *   - specificAssetIds match exactly the keyValueCombinations
+    *   - if externalSubjectId (tenantId) is not null it must match the tenantId
+    *
+    *
+    * To be able to properly index the key and value conditions, the query does not use any functions.
+    * Computed indexes cannot be created for mutable functions like CONCAT in Postgres.
+    *
+    * @param keyValueCombinations the keys values to search for as tuples
+    * @param keyValueCombinationsSize the size of the key value combinations
+    * @return external shell ids for the given key value combinations
+    */
+   @Query( value = """
+         SELECT s.id_external
+         FROM shell s
+            JOIN shell_identifier si ON s.id = si.fk_shell_id
+         WHERE
+            CONCAT(si.namespace, si.identifier) IN (:keyValueCombinations)
+            AND (
+               :tenantId = :owningTenantId
+               OR si.namespace = :globalAssetId
+               OR EXISTS (
+                  SELECT 1
+                  FROM SHELL_IDENTIFIER_EXTERNAL_SUBJECT_REFERENCE_KEY sider
+                     JOIN SHELL_IDENTIFIER_EXTERNAL_SUBJECT_REFERENCE sies ON sider.FK_SI_EXTERNAL_SUBJECT_REFERENCE_ID = sies.id
+                  WHERE
+                     (
+                        sider.ref_key_value = :tenantId
+                        OR ( sider.ref_key_value = :publicWildcardPrefix AND si.namespace IN (:publicWildcardAllowedTypes) )
+                     )
+                     AND sies.FK_SHELL_IDENTIFIER_EXTERNAL_SUBJECT_ID = si.id
+               )
+            )
+         GROUP BY s.id_external
+         HAVING COUNT(*) = :keyValueCombinationsSize
+         """, nativeQuery = true )
+   List<String> findExternalShellIdsByIdentifiersByExactMatch( @Param( "keyValueCombinations" ) List<String> keyValueCombinations,
+         @Param( "keyValueCombinationsSize" ) int keyValueCombinationsSize,
+         @Param( "tenantId" ) String tenantId,
+         @Param( "publicWildcardPrefix" ) String publicWildcardPrefix,
+         @Param( "publicWildcardAllowedTypes" ) List<String> publicWildcardAllowedTypes,
+         @Param( "owningTenantId" ) String owningTenantId,
+         @Param( "globalAssetId" ) String globalAssetId );
 }

--- a/backend/src/main/java/org/eclipse/tractusx/semantics/registry/repository/ShellRepository.java
+++ b/backend/src/main/java/org/eclipse/tractusx/semantics/registry/repository/ShellRepository.java
@@ -81,52 +81,6 @@ public interface ShellRepository extends JpaRepository<Shell, UUID>, JpaSpecific
 
    /**
     * Returns external shell ids for the given keyValueCombinations.
-    * External shell ids matching the conditions below are returned:
-    *   - specificAssetIds match exactly the keyValueCombinations
-    *   - if externalSubjectId (tenantId) is not null it must match the tenantId
-    *
-    *
-    * To be able to properly index the key and value conditions, the query does not use any functions.
-    * Computed indexes cannot be created for mutable functions like CONCAT in Postgres.
-    *
-    * @param keyValueCombinations the keys values to search for as tuples
-    * @param keyValueCombinationsSize the size of the key value combinations
-    * @return external shell ids for the given key value combinations
-    */
-   @Query( value = """
-         SELECT s.id_external
-         FROM shell s
-            JOIN shell_identifier si ON s.id = si.fk_shell_id
-         WHERE
-            CONCAT(si.namespace, si.identifier) IN (:keyValueCombinations)
-            AND (
-               :tenantId = :owningTenantId
-               OR si.namespace = :globalAssetId
-               OR EXISTS (
-                  SELECT 1
-                  FROM SHELL_IDENTIFIER_EXTERNAL_SUBJECT_REFERENCE_KEY sider
-                     JOIN SHELL_IDENTIFIER_EXTERNAL_SUBJECT_REFERENCE sies ON sider.FK_SI_EXTERNAL_SUBJECT_REFERENCE_ID = sies.id
-                  WHERE
-                     (
-                        sider.ref_key_value = :tenantId
-                        OR ( sider.ref_key_value = :publicWildcardPrefix AND si.namespace IN (:publicWildcardAllowedTypes) )
-                     )
-                     AND sies.FK_SHELL_IDENTIFIER_EXTERNAL_SUBJECT_ID = si.id
-               )
-            )
-         GROUP BY s.id_external
-         HAVING COUNT(*) = :keyValueCombinationsSize
-         """, nativeQuery = true )
-   List<String> findExternalShellIdsByIdentifiersByExactMatch( @Param( "keyValueCombinations" ) List<String> keyValueCombinations,
-         @Param( "keyValueCombinationsSize" ) int keyValueCombinationsSize,
-         @Param( "tenantId" ) String tenantId,
-         @Param( "publicWildcardPrefix" ) String publicWildcardPrefix,
-         @Param( "publicWildcardAllowedTypes" ) List<String> publicWildcardAllowedTypes,
-         @Param( "owningTenantId" ) String owningTenantId,
-         @Param( "globalAssetId" ) String globalAssetId );
-
-   /**
-    * Returns external shell ids for the given keyValueCombinations.
     * External shell ids that match any keyValueCombinations are returned.
     *
     * To be able to properly index the key and value conditions, the query does not use any functions.

--- a/backend/src/main/java/org/eclipse/tractusx/semantics/registry/service/ShellService.java
+++ b/backend/src/main/java/org/eclipse/tractusx/semantics/registry/service/ShellService.java
@@ -204,7 +204,7 @@ public class ShellService {
          Page<Shell> currentPage = shellRepository.findAll( specification, ofSize( fetchSize ) );
          List<Shell> shells = shellAccessHandler.filterListOfShellProperties( currentPage.stream().toList(), externalSubjectId );
          shells.stream()
-               .limit( (long) pageSize - foundList.size() )
+               .limit( (long) fetchSize - foundList.size() )
                .forEach( foundList::add );
          hasNext = currentPage.hasNext();
       }
@@ -278,7 +278,7 @@ public class ShellService {
                   .forEach( assetIdList::add );
             nextCursor = getCursorEncoded( allVisible, assetIdList );
          } else {
-            List<String> queryResult = shellRepository.findExternalShellIdsByIdentifiersByExactMatch( keyValueCombinations,
+            List<String> queryResult = shellIdentifierRepository.findExternalShellIdsByIdentifiersByExactMatch( keyValueCombinations,
                   keyValueCombinations.size(), externalSubjectId, externalSubjectIdWildcardPrefix, externalSubjectIdWildcardAllowedTypes, owningTenantId,
                   ShellIdentifier.GLOBAL_ASSET_ID_KEY );
             pageSize = getPageSize( pageSize );


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description

- Moves ShellRepository.findExternalShellIdsByIdentifiersByExactMatch to ShellIdentifierRepository
- Fixes service method listing all shells

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->
Related to #287 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
