### PR TITLE
feat: Implementation of CRUD API for Access management APIs - Access rule API tests

### DIFF
--- a/backend/src/test/java/org/eclipse/tractusx/semantics/registry/JwtTokenFactory.java
+++ b/backend/src/test/java/org/eclipse/tractusx/semantics/registry/JwtTokenFactory.java
@@ -103,7 +103,10 @@ public class JwtTokenFactory {
                List.of( AuthorizationEvaluator.Roles.ROLE_VIEW_DIGITAL_TWIN,
                      AuthorizationEvaluator.Roles.ROLE_ADD_DIGITAL_TWIN,
                      AuthorizationEvaluator.Roles.ROLE_UPDATE_DIGITAL_TWIN,
-                     AuthorizationEvaluator.Roles.ROLE_DELETE_DIGITAL_TWIN )
+                     AuthorizationEvaluator.Roles.ROLE_DELETE_DIGITAL_TWIN,
+                     AuthorizationEvaluator.Roles.ROLE_SUBMODEL_ACCESS_CONTROL,
+                     AuthorizationEvaluator.Roles.ROLE_READ_ACCESS_RULES,
+                     AuthorizationEvaluator.Roles.ROLE_WRITE_ACCESS_RULES )
          );
       }
 
@@ -125,6 +128,14 @@ public class JwtTokenFactory {
 
       public RequestPostProcessor submodelAccessControl() {
          return authenticationWithRoles( tenantId, List.of( AuthorizationEvaluator.Roles.ROLE_SUBMODEL_ACCESS_CONTROL ) );
+      }
+
+      public RequestPostProcessor readAccessRules() {
+         return authenticationWithRoles( tenantId, List.of( AuthorizationEvaluator.Roles.ROLE_READ_ACCESS_RULES ) );
+      }
+
+      public RequestPostProcessor writeAccessRules() {
+         return authenticationWithRoles( tenantId, List.of( AuthorizationEvaluator.Roles.ROLE_WRITE_ACCESS_RULES ) );
       }
 
       public RequestPostProcessor withoutResourceAccess() {


### PR DESCRIPTION


<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description

- Adds tests covering the access rule specific API

Updates #286 

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
