### PR TITLE
Autogenerate PW if not set for postgres helm

### DIFF
--- a/DOCKER_NOTICE.md
+++ b/DOCKER_NOTICE.md
@@ -1,0 +1,27 @@
+## Notice for Docker image
+This application provides container images for demonstrations purposes.
+
+DockerHub:  [Docker.io:tractusx-digital-twin-registry](https://hub.docker.com/r/tractusx/sldt-digital-twin-registry)
+
+The Docker images from version 0.3.3-M1 until the latest can be found on DockerHub, older versions have been published on GitHub Container Registry (GHCR): [catena-ng:digital-twin-registry](https://github.com/catenax-ng/product-semantics/pkgs/container/sldt-digital-twin-registry)
+
+The Helm chart can be found at the GitHub repository at: [Releases](https://github.com/eclipse-tractusx/sldt-digital-twin-registry/releases) <br/>
+
+Eclipse Tractus-X product(s) installed within the image:
+
+Digital Twin Registry
+
+- GitHub: https://github.com/eclipse-tractusx/sldt-digital-twin-registry
+- Project home: https://projects.eclipse.org/projects/automotive.tractusx
+- Dockerfile: https://github.com/eclipse-tractusx/sldt-digital-twin-registry/blob/main/backend/Dockerfile
+- Project license: [Apache License, Version 2.0](https://github.com/eclipse-tractusx/sldt-digital-twin-registry/blob/main/LICENSE)
+
+**Used base image**
+- [eclipse-temurin:17-jre-alpine](https://github.com/adoptium/containers)
+- Official Eclipse Temurin DockerHub page: https://hub.docker.com/_/eclipse-temurin
+- Eclipse Temurin Project: https://projects.eclipse.org/projects/adoptium.temurin
+- Additional information about the Eclipse Temurin images: https://github.com/docker-library/repo-info/tree/master/repos/eclipse-temurin
+
+As with all Docker images, these likely also contain other software which may be under other licenses (such as Bash, etc from the base distribution, along with any direct or indirect dependencies of the primary software being contained).
+
+As for any pre-built image usage, it is the image user's responsibility to ensure that any use of this image complies with any relevant licenses for all software contained within.

--- a/README.md
+++ b/README.md
@@ -36,27 +36,3 @@ In case you want to publish your image into a remote container registry, apply t
 
 ## Install Instructions
 For detailed install instructions please refer to our [INSTALL.md](https://github.com/eclipse-tractusx/sldt-digital-twin-registry/blob/main/INSTALL.md)
-
-## Notice for Docker image
-
-DockerHub:  [Docker.io:tractusx-digital-twin-registry](https://hub.docker.com/r/tractusx/sldt-digital-twin-registry) <br/>
-The Docker images from version 0.3.3-M1 until the latest can be found on DockerHub, older versions have been published on GitHub Container Registry (GHCR): [catena-ng:digital-twin-registry](https://github.com/catenax-ng/product-semantics/pkgs/container/sldt-digital-twin-registry)
-
-The Helm chart can be found at the GitHub repository at: [Releases](https://github.com/eclipse-tractusx/sldt-digital-twin-registry/releases) <br/>
-This application provides container images for demonstration purposes.
-Eclipse Tractus-X product(s) installed within the image:
-
-- GitHub: https://github.com/eclipse-tractusx/sldt-digital-twin-registry
-- Project home: https://projects.eclipse.org/projects/automotive.tractusx
-- Dockerfile: https://github.com/eclipse-tractusx/sldt-digital-twin-registry/blob/main/backend/Dockerfile
-- Project license: [Apache License, Version 2.0](https://github.com/eclipse-tractusx/sldt-digital-twin-registry/blob/main/LICENSE)
-
-**Used base image**
-- [eclipse-temurin:17-jre-alpine](https://github.com/adoptium/containers)
-- Official Eclipse Temurin DockerHub page: https://hub.docker.com/_/eclipse-temurin  
-- Eclipse Temurin Project: https://projects.eclipse.org/projects/adoptium.temurin  
-- Additional information about the Eclipse Temurin images: https://github.com/docker-library/repo-info/tree/master/repos/eclipse-temurin
-
-As with all Docker images, these likely also contain other software which may be under other licenses (such as Bash, etc from the base distribution, along with any direct or indirect dependencies of the primary software being contained).
-
-As for any pre-built image usage, it is the image user's responsibility to ensure that any use of this image complies with any relevant licenses for all software contained within.

--- a/charts/registry/Chart.yaml
+++ b/charts/registry/Chart.yaml
@@ -26,8 +26,8 @@ sources:
   - https://github.com/eclipse-tractusx/sldt-digital-twin-registry
 
 type: application
-version: 0.3.30
-appVersion: 0.3.22
+version: 0.3.33
+appVersion: 0.3.23
 
 dependencies:
   - repository: https://charts.bitnami.com/bitnami

--- a/charts/registry/templates/_helpers.tpl
+++ b/charts/registry/templates/_helpers.tpl
@@ -1,0 +1,15 @@
+{{/*
+Determine database hostname
+*/}}
+{{- define "dtr.postgres.primary.fullname" -}}
+{{- if .Values.postgresql.fullnameOverride -}}
+{{- .Values.postgresql.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default "postgresql" .Values.postgresql.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/charts/registry/templates/registry/postgres-init.yaml
+++ b/charts/registry/templates/registry/postgres-init.yaml
@@ -1,0 +1,62 @@
+################################################################################
+# Copyright (c) 2024 Robert Bosch Manufacturing Solutions GmbH and others
+# Copyright (c) 2024 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+################################################################################
+
+{{- if .Values.enablePostgres }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.postgresql.auth.existingSecret }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-install, pre-upgrade
+type: Opaque
+{{- $secret := (lookup "v1" "Secret" .Release.Namespace .Values.postgresql.auth.existingSecret) }}
+{{- $defaultSecret := (lookup "v1" "Secret" .Release.Namespace ( printf "%s-postgresql" .Release.Name )) }}
+# 1. Check if given secret exists
+{{ if $secret -}}
+data:
+  {{- $postgresPassword:= ( .Values.postgresql.auth.password | b64enc) | default ( index $secret.data "postgres-password" ) | quote }}
+  postgres-password: {{ $postgresPassword }}
+  {{- $password:= ( .Values.postgresql.auth.password | b64enc) | default ( index $secret.data "password" ) | quote }}
+  password: {{ $password }}
+  SPRING_DATASOURCE_PASSWORD: {{ $password }}
+  SPRING_DATASOURCE_URL: {{ printf "jdbc:postgresql://%s:%v/%s" (include "dtr.postgres.primary.fullname" .) .Values.postgresql.service.ports.postgresql .Values.postgresql.auth.database | b64enc }}
+  SPRING_DATASOURCE_USERNAME: {{ .Values.postgresql.auth.username | b64enc }}
+# 2. Check if default postgresql secret (Release.Name-postgresql) exists
+{{ else if $defaultSecret -}}
+data:
+  {{- $postgresPassword:= ( .Values.postgresql.auth.password | b64enc) | default ( index $defaultSecret.data "postgres-password" ) | quote }}
+  postgres-password: {{ $postgresPassword }}
+  {{- $password:= ( .Values.postgresql.auth.password | b64enc) | default ( index $defaultSecret.data "password" ) | quote }}
+  password: {{ $password }}
+  SPRING_DATASOURCE_PASSWORD: {{ $password }}
+  SPRING_DATASOURCE_URL: {{ printf "jdbc:postgresql://%s:%v/%s" (include "dtr.postgres.primary.fullname" .) .Values.postgresql.service.ports.postgresql .Values.postgresql.auth.database | b64enc }}
+  SPRING_DATASOURCE_USERNAME: {{ .Values.postgresql.auth.username | b64enc }}
+{{ else -}}
+# 3. If no secret exists, use provided value from values file or generate a random one if secret not exists.
+stringData:
+  {{- $password:= .Values.postgresql.auth.password | default ( randAlphaNum 32 ) | quote }}
+  postgres-password: {{ $password }}
+  password: {{ $password }}
+  SPRING_DATASOURCE_PASSWORD: {{ $password }}
+  SPRING_DATASOURCE_URL: {{ printf "jdbc:postgresql://%s:%v/%s" (include "dtr.postgres.primary.fullname" .) .Values.postgresql.service.ports.postgresql .Values.postgresql.auth.database }}
+  SPRING_DATASOURCE_USERNAME: {{ .Values.postgresql.auth.username }}
+{{ end }}
+{{- end -}}

--- a/charts/registry/templates/registry/registry-deployment.yaml
+++ b/charts/registry/templates/registry/registry-deployment.yaml
@@ -1,6 +1,6 @@
 ###############################################################
-# Copyright (c) 2021, 2023 Robert Bosch Manufacturing Solutions GmbH
-# Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2021 Robert Bosch Manufacturing Solutions GmbH
+# Copyright (c) 2021 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -71,6 +71,10 @@ spec:
           envFrom:
             - secretRef:
                 name: {{ $sec_name }}
+            {{- if .Values.enablePostgres }}
+            - secretRef:
+                name: {{ .Values.postgresql.auth.existingSecret }}
+            {{- end }}
           resources:
 {{ .Values.registry.resources | toYaml | indent 12 }}
       imagePullSecrets:

--- a/charts/registry/templates/registry/registry-secret.yaml
+++ b/charts/registry/templates/registry/registry-secret.yaml
@@ -1,6 +1,6 @@
 ###############################################################
-# Copyright (c) 2021, 2023 Robert Bosch Manufacturing Solutions GmbH
-# Copyright (c) 2021, 2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2021 Robert Bosch Manufacturing Solutions GmbH
+# Copyright (c) 2021 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
 # information regarding copyright ownership.
@@ -26,11 +26,8 @@ metadata:
   name: {{ $sec_name }}
 type: Opaque
 data:
-  {{- if .Values.enablePostgres }}
-  SPRING_DATASOURCE_URL: {{ printf "jdbc:postgresql://%s-postgresql:%v/%s" .Release.Name .Values.postgresql.service.ports.postgresql .Values.postgresql.auth.database | b64enc }}
-  SPRING_DATASOURCE_USERNAME: {{ .Values.postgresql.auth.username | b64enc }}
-  SPRING_DATASOURCE_PASSWORD: {{ .Values.postgresql.auth.password | b64enc }}
-  {{- else }}
+  # If postgres enabled the environment values will be used from postgres-init.yaml
+  {{- if not .Values.enablePostgres }}
   SPRING_DATASOURCE_URL: {{ .Values.registry.dataSource.url | b64enc }}
   SPRING_DATASOURCE_USERNAME: {{ .Values.registry.dataSource.user | b64enc }}
   SPRING_DATASOURCE_PASSWORD: {{ .Values.registry.dataSource.password | b64enc }}

--- a/charts/registry/values.yaml
+++ b/charts/registry/values.yaml
@@ -58,7 +58,7 @@ registry:
     ## In that case the postgresql auth parameters are used.
     url: jdbc:postgresql://database:5432
     user: default-user
-    password: ""
+    password:
   ingress:
     enabled: false
     tls: false
@@ -90,8 +90,10 @@ postgresql:
       postgresql: 5432
   auth:
     username: default-user
-    password: password
+    password:
     database: default-database
+    # -- Secret contains passwords for username postgres.
+    existingSecret: secret-dtr-postgres-init
 
 keycloak:
   postgresql:


### PR DESCRIPTION


<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
Remove hardcoded pw from helm and generate random if pw is not set for postgres
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
