### PR TITLE
Feat: Lookup API v3.1 POST Get Shell IDS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.4.1-RC3
+### Added
+- Added API POST lookup/shellsByAssetLink to retrieve shell ids without base64 encryption.
+- Added v3.1.0 postman collection for new API.
+## fixed
+
 ## 0.4.1-RC2
 ### Added
 - Update Springboot to version 3.2.3

--- a/backend/src/main/java/org/eclipse/tractusx/semantics/registry/controller/AssetAdministrationShellApiDelegate.java
+++ b/backend/src/main/java/org/eclipse/tractusx/semantics/registry/controller/AssetAdministrationShellApiDelegate.java
@@ -22,7 +22,6 @@ package org.eclipse.tractusx.semantics.registry.controller;
 
 import java.util.Base64;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -32,9 +31,11 @@ import org.eclipse.tractusx.semantics.aas.registry.api.LookupApiDelegate;
 import org.eclipse.tractusx.semantics.aas.registry.api.ShellDescriptorsApiDelegate;
 import org.eclipse.tractusx.semantics.aas.registry.model.AssetAdministrationShellDescriptor;
 import org.eclipse.tractusx.semantics.aas.registry.model.AssetKind;
+import org.eclipse.tractusx.semantics.aas.registry.model.AssetLink;
 import org.eclipse.tractusx.semantics.aas.registry.model.GetAllAssetAdministrationShellIdsByAssetLink200Response;
 import org.eclipse.tractusx.semantics.aas.registry.model.GetAssetAdministrationShellDescriptorsResult;
 import org.eclipse.tractusx.semantics.aas.registry.model.GetSubmodelDescriptorsResult;
+import org.eclipse.tractusx.semantics.aas.registry.model.SearchAllShellsByAssetLink200Response;
 import org.eclipse.tractusx.semantics.aas.registry.model.ServiceDescription;
 import org.eclipse.tractusx.semantics.aas.registry.model.SpecificAssetId;
 import org.eclipse.tractusx.semantics.aas.registry.model.SubmodelDescriptor;
@@ -174,6 +175,19 @@ public class AssetAdministrationShellApiDelegate implements DescriptionApiDelega
         final var result  = shellService.findExternalShellIdsByIdentifiersByExactMatch(
               shellMapper.fromApiDto(listSpecificAssetId), limit, cursor,getExternalSubjectIdOrEmpty(externalSubjectId));
        return new ResponseEntity<>( result, HttpStatus.OK );
+    }
+
+    @Override
+    public ResponseEntity<SearchAllShellsByAssetLink200Response> searchAllShellsByAssetLink(
+          Integer limit, String cursor, @RequestHeader String externalSubjectId,List<AssetLink> assetIds) {
+
+        if (assetIds == null || assetIds.isEmpty()) {
+            return new ResponseEntity<>(new SearchAllShellsByAssetLink200Response(), HttpStatus.OK);
+        }
+
+        final var result  = shellService.findExternalShellIdsByAssetLinkByExactMatch(
+              shellMapper.fromAssetLinkApiDto(assetIds), limit, cursor,getExternalSubjectIdOrEmpty(externalSubjectId));
+        return new ResponseEntity<>( result, HttpStatus.OK );
     }
 
     private SpecificAssetId decodeSAID(byte[] encodedId){

--- a/backend/src/main/java/org/eclipse/tractusx/semantics/registry/mapper/ShellMapper.java
+++ b/backend/src/main/java/org/eclipse/tractusx/semantics/registry/mapper/ShellMapper.java
@@ -61,6 +61,13 @@ public interface ShellMapper {
     })
     ShellIdentifier fromApiDto(SpecificAssetId apiDto);
 
+   @Mappings({
+         @Mapping(target = "key", source = "name"),
+   })
+   ShellIdentifier fromApiDto(AssetLink apiDto);
+
+   Set<ShellIdentifier> fromAssetLinkApiDto(List<AssetLink> apiDto);
+
    ShellIdentifierSupplemSemanticReference maptoShellIdentifierSupplemSemanticReference ( Reference supplementalSemanticId );
 
    ShellIdentifierSemanticReference maptoShellIdentifierSemanticReference ( Reference semanticId );

--- a/backend/src/main/resources/static/aas-registry-openapi.yaml
+++ b/backend/src/main/resources/static/aas-registry-openapi.yaml
@@ -744,6 +744,59 @@ paths:
                   $ref: '#/components/examples/lookup-shells-by-aas-identifier-response'
       x-semanticIds:
         - https://admin-shell.io/aas/API/GetAllAssetAdministrationShellIdsByAssetLink/1/0/RC02
+  /lookup/shellsByAssetLink:
+    post:
+      tags:
+        - Registry and Discovery Interface
+      summary: Returns a list of Asset Administration Shell ids linked to specific Asset identifiers
+      operationId: SearchAllShellsByAssetLink
+      x-semanticIds:
+        - https://admin-shell.io/aas/API/SearchAllAssetAdministrationShellIdsByAssetLink/3/1
+      parameters:
+        - name: limit
+          in: query
+          description: The maximum number of elements in the response array
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+        - name: cursor
+          in: query
+          description: A server-generated identifier retrieved from pagingMetadata that specifies from which position the result listing should continue
+          required: false
+          schema:
+            type: string
+        - $ref: '#/components/parameters/ExternalSubjectIdHeader'
+      requestBody:
+        description: Asset identifier key-value-pairs
+        content:
+          application/json:
+            schema:
+              type: array
+              maxItems: 10000
+              items:
+                $ref: '#/components/schemas/AssetLink'
+            examples:
+              complete:
+                $ref: '#/components/examples/lookup-shells-by-aas-identifier-post'
+      responses:
+        '200':
+          description: Requested Asset Administration Shell ids
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/PagedResult'
+                  - type: object
+                    properties:
+                      result:
+                        type: array
+                        items:
+                          type: string
+        '400':
+          $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.1.0#/components/responses/bad-request'
+        default:
+          $ref: 'https://api.swaggerhub.com/domains/Plattform_i40/Part2-API-Schemas/V3.1.0#/components/responses/default'
   /lookup/shells/{aasIdentifier}:
     get:
       tags:
@@ -1401,6 +1454,18 @@ components:
           maxItems: 10000
           items:
             $ref: '#/components/schemas/ProtocolInformation_securityAttributes'
+    AssetLink:
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 64
+          pattern: "^([\\t\\n\\r -\ud7ff\ue000-\ufffd]|\\ud800[\\udc00-\\udfff]|[\\ud801-\\udbfe][\\udc00-\\udfff]|\\udbff[\\udc00-\\udfff])*$"
+        value:
+          type: string
+          minLength: 1
+          maxLength: 2000
+          pattern: "^([\\t\\n\\r -\ud7ff\ue000-\ufffd]|\\ud800[\\udc00-\\udfff]|[\\ud801-\\udbfe][\\udc00-\\udfff]|\\udbff[\\udc00-\\udfff])*$"
     SpecificAssetId:
       type: object
       allOf:
@@ -1653,6 +1718,18 @@ components:
         description: Incoming external_subject_id/bpn
   #        format: byte
   examples:
+    lookup-shells-by-aas-identifier-post:
+      value:
+        [
+          {
+            "name": "globalAssetId",
+            "value": "urn:uuid:882fc530-b69b-4707-95f6-5dbc5e9baaa8"
+          },
+          {
+            "name": "PartInstanceID",
+            "value": "24975539203421"
+          }
+        ]
     lookup-shells-by-aas-identifier-query:
       value:
         [

--- a/backend/src/test/java/org/eclipse/tractusx/semantics/registry/AbstractAssetAdministrationShellApi.java
+++ b/backend/src/test/java/org/eclipse/tractusx/semantics/registry/AbstractAssetAdministrationShellApi.java
@@ -49,6 +49,7 @@ public abstract class AbstractAssetAdministrationShellApi {
     protected static final String SHELL_BASE_PATH = "/api/v3.0/shell-descriptors";
     protected static final String SINGLE_SHELL_BASE_PATH = "/api/v3.0/shell-descriptors/{aasIdentifier}";
     protected static final String LOOKUP_SHELL_BASE_PATH = "/api/v3.0/lookup/shells";
+    protected static final String LOOKUP_SHELL_BASE_PATH_POST = "/api/v3.0/lookup/shellsByAssetLink";
     protected static final String SINGLE_LOOKUP_SHELL_BASE_PATH = "/api/v3.0/lookup/shells/{aasIdentifier}";
     protected static final String SUB_MODEL_BASE_PATH = "/api/v3.0/shell-descriptors/{aasIdentifier}/submodel-descriptors";
     protected static final String SINGLE_SUB_MODEL_BASE_PATH = "/api/v3.0/shell-descriptors/{aasIdentifier}/submodel-descriptors/{submodelIdentifier}";

--- a/backend/src/test/java/org/eclipse/tractusx/semantics/registry/AssetAdministrationShellApiTest.java
+++ b/backend/src/test/java/org/eclipse/tractusx/semantics/registry/AssetAdministrationShellApiTest.java
@@ -24,12 +24,14 @@ import static org.eclipse.tractusx.semantics.registry.TestUtil.*;
 import static org.hamcrest.Matchers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
 import java.util.UUID;
 
 import org.apache.commons.lang3.RandomStringUtils;
 import org.eclipse.tractusx.semantics.aas.registry.model.AssetAdministrationShellDescriptor;
+import org.eclipse.tractusx.semantics.aas.registry.model.AssetLink;
 import org.eclipse.tractusx.semantics.aas.registry.model.LangStringTextType;
 import org.eclipse.tractusx.semantics.aas.registry.model.SpecificAssetId;
 import org.eclipse.tractusx.semantics.aas.registry.model.SubmodelDescriptor;
@@ -774,6 +776,73 @@ public class AssetAdministrationShellApiTest extends AbstractAssetAdministration
                .andExpect( jsonPath( "$.result", hasSize( 0 ) ) );
       }
 
+
+      @Test
+      public void testFindExternalShellIdsByAssetLinkExpectSuccess() throws Exception {
+
+         AssetAdministrationShellDescriptor shellPayload1 = TestUtil.createCompleteAasDescriptor();
+         shellPayload1.setId( UUID.randomUUID().toString() );
+         performShellCreateRequest( mapper.writeValueAsString( shellPayload1 ) );
+
+         AssetAdministrationShellDescriptor shellPayload2 = TestUtil.createCompleteAasDescriptor();
+         shellPayload2.setId( UUID.randomUUID().toString() );
+         performShellCreateRequest( mapper.writeValueAsString( shellPayload2 ) );
+
+         AssetLink assetLink1 = TestUtil.createAssetLink();
+         List<AssetLink> list1 = new ArrayList<>();
+         list1.add( assetLink1 );
+
+         mvc.perform(
+                     MockMvcRequestBuilders
+                           .post( LOOKUP_SHELL_BASE_PATH_POST )
+                           .queryParam( "limit", "1" )
+                           .header( EXTERNAL_SUBJECT_ID_HEADER, jwtTokenFactory.tenantOne().getTenantId() )
+                           .accept( MediaType.APPLICATION_JSON )
+                           .contentType( MediaType.APPLICATION_JSON )
+                           .content( mapper.writeValueAsBytes(list1) )
+                           .with( jwtTokenFactory.allRoles() )
+               )
+               .andDo( MockMvcResultHandlers.print() )
+               .andExpect( status().isOk() )
+               .andExpect( jsonPath( "$.paging_metadata.cursor" ).exists() );
+
+         // Test first shell match with single assetLink
+
+         AssetLink assetLink2 = TestUtil.createAssetLink( "identifier99KeyExample", "identifier99ValueExample" );
+         List<AssetLink> list2 = new ArrayList<>();
+         list2.add( assetLink2 );
+         mvc.perform(
+                     MockMvcRequestBuilders
+                           .post( LOOKUP_SHELL_BASE_PATH_POST )
+                           .queryParam( "limit", "10" )
+                           .accept( MediaType.APPLICATION_JSON )
+                           .contentType( MediaType.APPLICATION_JSON )
+                           .content( mapper.writeValueAsBytes(list2) )
+                           .with( jwtTokenFactory.allRoles() )
+               )
+               .andDo( MockMvcResultHandlers.print() )
+               .andExpect( status().isOk() )
+               .andExpect( jsonPath( "$.paging_metadata.cursor" ).doesNotExist() );
+
+         // Test first and second shell match with common assetLink
+
+         AssetLink assetLink3 = TestUtil.createAssetLink( "commonAssetIdKey", "commonAssetIdValue" );
+         List<AssetLink> list3 = new ArrayList<>();
+         list3.add( assetLink3 );
+         mvc.perform(
+                     MockMvcRequestBuilders
+                           .post( LOOKUP_SHELL_BASE_PATH_POST )
+                           .queryParam( "limit", "10" )
+                           .accept( MediaType.APPLICATION_JSON )
+                           .contentType( MediaType.APPLICATION_JSON )
+                           .content( mapper.writeValueAsBytes(list3) )
+                           .with( jwtTokenFactory.allRoles() )
+               )
+               .andDo( MockMvcResultHandlers.print() )
+               .andExpect( status().isOk() )
+               .andExpect( jsonPath( "$.result", hasSize( 0 ) ) );
+      }
+
       @Test
       public void testFindExternalShellIdByGlobalAssetIdExpectSuccess() throws Exception {
 
@@ -796,6 +865,39 @@ public class AssetAdministrationShellApiTest extends AbstractAssetAdministration
                            .header( EXTERNAL_SUBJECT_ID_HEADER, jwtTokenFactory.tenantOne().getTenantId() )
                            .queryParam( "assetIds", encodedSa1)
                            .accept( MediaType.APPLICATION_JSON )
+                           .with( jwtTokenFactory.allRoles() )
+               )
+               .andDo( MockMvcResultHandlers.print() )
+               .andExpect( status().isOk() )
+               .andExpect( jsonPath( "$.result", hasSize( 1 ) ) )
+               // ensure that only three results match
+               .andExpect( jsonPath( "$.result", contains( shellPayload.getId() ) ) );
+      }
+
+      @Test
+      public void testFindExternalShellIdByGlobalAssetIdAssetLinkExpectSuccess() throws Exception {
+
+         String globalAssetId = UUID.randomUUID().toString();
+
+         AssetAdministrationShellDescriptor shellPayload = TestUtil.createCompleteAasDescriptor();
+         shellPayload.setId( UUID.randomUUID().toString() );
+         shellPayload.setGlobalAssetId( globalAssetId );
+         String payload = mapper.writeValueAsString( shellPayload );
+         performShellCreateRequest(payload );
+
+         // for lookup global asset id is handled as AssetLink
+         AssetLink SAGlobal = TestUtil.createAssetLink("globalAssetId",globalAssetId);
+
+         List<AssetLink> list = new ArrayList<>();
+         list.add( SAGlobal );
+
+         mvc.perform(
+                     MockMvcRequestBuilders
+                           .post( LOOKUP_SHELL_BASE_PATH_POST )
+                           .header( EXTERNAL_SUBJECT_ID_HEADER, jwtTokenFactory.tenantOne().getTenantId() )
+                           .accept( MediaType.APPLICATION_JSON )
+                           .contentType( MediaType.APPLICATION_JSON )
+                           .content( mapper.writeValueAsBytes(list) )
                            .with( jwtTokenFactory.allRoles() )
                )
                .andDo( MockMvcResultHandlers.print() )

--- a/backend/src/test/java/org/eclipse/tractusx/semantics/registry/TestUtil.java
+++ b/backend/src/test/java/org/eclipse/tractusx/semantics/registry/TestUtil.java
@@ -33,6 +33,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.eclipse.tractusx.semantics.aas.registry.model.AssetAdministrationShellDescriptor;
 import org.eclipse.tractusx.semantics.aas.registry.model.AssetKind;
+import org.eclipse.tractusx.semantics.aas.registry.model.AssetLink;
 import org.eclipse.tractusx.semantics.aas.registry.model.Endpoint;
 import org.eclipse.tractusx.semantics.aas.registry.model.Key;
 import org.eclipse.tractusx.semantics.aas.registry.model.KeyTypes;
@@ -240,6 +241,20 @@ public class TestUtil {
       specificAssetId1.setSupplementalSemanticIds( List.of( reference ) );
       specificAssetId1.setExternalSubjectId( reference );
       return specificAssetId1;
+   }
+
+   public static AssetLink createAssetLink() {
+      AssetLink assetLink = new AssetLink();
+      assetLink.setName( "identifier1KeyExample" );
+      assetLink.setValue( "identifier1ValueExample" );
+      return assetLink;
+   }
+
+   public static AssetLink createAssetLink(String name, String value) {
+      AssetLink assetLink = new AssetLink();
+      assetLink.setName( name );
+      assetLink.setValue( value );
+      return assetLink;
    }
 
    public static SpecificAssetId createSpecificAssetId( String name, String value, List<String> externalSubjectIds ) {

--- a/docs/development/postman/tractusx-dtr-aas-3.1.0-collection.json
+++ b/docs/development/postman/tractusx-dtr-aas-3.1.0-collection.json
@@ -1,0 +1,609 @@
+{
+	"info": {
+		"_postman_id": "a55b763d-91cc-43e4-a3b9-615edab5dc52",
+		"name": "tractusx-dtr-aas-3.0.0 Copy",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "28393378"
+	},
+	"item": [
+		{
+			"name": "Asset Administration Shell Registry",
+			"item": [
+				{
+					"name": "Create Shell",
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"idShort\": \"idShortExample\",\n  \"id\": \"e1eba3d7-91f0-4dac-a730-eaa1d35e035c-2\",  \n  \"description\": [\n    {\n      \"language\": \"de\",\n      \"text\": \"example text\"\n    }\n  ],\n  \"displayName\": [\n    {\n      \"language\": \"de\",\n      \"text\": \"this is an example description1\"\n    }\n  ],\n  \"specificAssetIds\": [\n    {\n      \"name\": \"manufacturePartId\",\n      \"value\": \"1234\"\n    },\n    {\n      \"name\": \"oen\",\n      \"value\": \"1239485\"\n    },\n    {\n      \"name\": \"serialnr\",\n      \"value\": \"12345\",\n      \"externalSubjectId\":{\n          \"type\": \"ExternalReference\",\n          \"keys\": [\n            {\n              \"type\": \"Property\",\n              \"value\": \"CONSUMER_BPN\"\n            }\n          ]\n        }\n    }\n  ],\n  \"submodelDescriptors\": [\n    {\n      \"endpoints\": [\n        {\n          \"interface\": \"interfaceNameExample\",\n          \"protocolInformation\": {\n            \"href\": \"endpointAddressExample\",\n            \"endpointProtocol\": \"endpointProtocolExample\",\n            \"endpointProtocolVersion\": [\n              \"e\"\n            ],\n            \"subprotocol\": \"5hg\",\n            \"subprotocolBody\":\"\",\n            \"subprotocolBodyEncoding\": \"subprotocolBodyExample\",\n            \"securityAttributes\": [\n              {\n                \"type\": \"NONE\",\n                \"key\": \"sec\",\n                \"value\": \"1\"\n              }\n            ]\n          }\n        }\n      ],\n      \"idShort\": \"idShortExample\",\n      \"id\": \"cd47615b-daf3-4036-8670-d2f89349d388-2\",\n      \"semanticId\": {\n        \"type\": \"ExternalReference\",\n        \"keys\": [\n          {\n            \"type\": \"Submodel\",\n            \"value\": \"urn:bamm:io.catenax.serial_part_typization:1.1.0#SerialPartTypization\"\n          }\n        ]\n      },\n      \"description\": [\n        {\n          \"language\": \"de\",\n          \"text\": \"hello text\"\n        },\n        {\n          \"language\": \"en\",\n          \"text\": \"hello s\"\n        }\n      ]\n    }\n  ]\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseUrl}}/api/v3.0/shell-descriptors",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"v3.0",
+								"shell-descriptors"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get All Shells",
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "GET",
+						"header": [
+							{
+								"key": "Edc-Bpn",
+								"value": "CONSUMER_BPN",
+								"description": "BPN (This is normally send via EDC)",
+								"type": "default"
+							}
+						],
+						"url": {
+							"raw": "{{baseUrl}}/api/v3.0/shell-descriptors",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"v3.0",
+								"shell-descriptors"
+							],
+							"query": [
+								{
+									"key": "limit",
+									"value": "100",
+									"disabled": true
+								},
+								{
+									"key": "cursor",
+									"value": null,
+									"disabled": true
+								},
+								{
+									"key": "",
+									"value": null,
+									"disabled": true
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get Shell by Id",
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "GET",
+						"header": [
+							{
+								"key": "Edc-Bpn",
+								"value": "",
+								"description": "BPN (This is normally send via EDC)",
+								"type": "default"
+							}
+						],
+						"url": {
+							"raw": "{{baseUrl}}/api/v3.0/shell-descriptors/:aasIdentifier",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"v3.0",
+								"shell-descriptors",
+								":aasIdentifier"
+							],
+							"variable": [
+								{
+									"key": "aasIdentifier",
+									"value": "ZTFlYmEzZDctOTFmMC00ZGFjLWE3MzAtZWFhMWQzNWUwMzVjLTI",
+									"description": "aasIdentifier as UTF8-BASE64-URL-encoded"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Update Shell",
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "PUT",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"idShort\": \"idShortExample\",\n  \"id\": \"e1eba3d7-91f0-4dac-a730-eaa1d35e035c-2\",\n  \"description\": [\n    {\n      \"language\": \"de\",\n      \"text\": \"example text\"\n    }\n  ],\n  \"displayName\": [\n    {\n      \"language\": \"de\",\n      \"text\": \"this is an example description1\"\n    }\n  ],\n  \"endpoints\": [\n    {\n      \"interface\": \"interfaceNameExample\",\n      \"protocolInformation\": {\n        \"href\": \"endpointAddressExample\",\n        \"endpointProtocol\": \"endpointProtocolExample\",\n        \"endpointProtocolVersion\": [\n          \"e\"\n        ],\n        \"subprotocol\": \"subprotocolExample\",\n        \"subprotocolBody\": \"subprotocolBodyExample\",\n        \"subprotocolBodyEncoding\": \"subprotocolBodyExample\",\n        \"securityAttributes\": [\n          {\n            \"type\": \"NONE\"\n          }\n        ]\n      }\n    }\n  ],\n  \"specificAssetIds\": [\n    {\n      \"name\": \"manufacturePartId\",\n      \"value\": \"12345\",\n      \"externalSubjectId\":{\n          \"type\": \"ExternalReference\",\n          \"keys\": [\n            {\n              \"type\": \"Property\",\n              \"value\": \"CONSUMER_BPN\"\n            }\n          ]\n        }\n    },\n    {\n      \"name\": \"oen\",\n      \"value\": \"1239485\"\n    },\n    {\n      \"name\": \"serialnr\",\n      \"value\": \"1234\",\n      \"externalSubjectId\":{\n          \"type\": \"ExternalReference\",\n          \"keys\": [\n            {\n              \"type\": \"Property\",\n              \"value\": \"CONSUMER_BPN\"\n            }\n          ]\n        }\n    }\n  ],\n  \"submodelDescriptors\": [\n    {\n      \"endpoints\": [\n        {\n          \"interface\": \"interfaceNameExample\",\n          \"protocolInformation\": {\n            \"href\": \"endpointAddressExample\",\n            \"endpointProtocol\": \"endpointProtocolExample\",\n            \"endpointProtocolVersion\": [\n              \"e\"\n            ],\n            \"subprotocol\": \"5hg\",\n            \"subprotocolBody\":\"\",\n            \"subprotocolBodyEncoding\": \"subprotocolBodyExample\",\n            \"securityAttributes\": [\n              {\n                \"type\": \"NONE\"\n              }\n            ]\n          }\n        }\n      ],\n      \"idShort\": \"idShortExample\",\n      \"id\": \"cd47615b-daf3-4036-8670-d2f89349d388-2\",\n      \"semanticId\": {\n        \"type\": \"ExternalReference\",\n        \"keys\": [\n          {\n            \"type\": \"Submodel\",\n            \"value\": \"urn:bamm:io.catenax.serial_part_typization:1.1.0#SerialPartTypization\"\n          }\n        ]\n      },\n      \"description\": [\n        {\n          \"language\": \"de\",\n          \"text\": \"hello text\"\n        },\n        {\n          \"language\": \"en\",\n          \"text\": \"hello s\"\n        }\n      ]\n    }\n  ]\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseUrl}}/api/v3.0/shell-descriptors/:aasIdentifier",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"v3.0",
+								"shell-descriptors",
+								":aasIdentifier"
+							],
+							"variable": [
+								{
+									"key": "aasIdentifier",
+									"value": "ZTFlYmEzZDctOTFmMC00ZGFjLWE3MzAtZWFhMWQzNWUwMzVjLTI",
+									"description": "aasIdentifier as UTF8-BASE64-URL-encoded"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Delete Shell",
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/api/v3.0/shell-descriptors/:aasIdentifier",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"v3.0",
+								"shell-descriptors",
+								":aasIdentifier"
+							],
+							"variable": [
+								{
+									"key": "aasIdentifier",
+									"value": "ZTFlYmEzZDctOTFmMC00ZGFjLWE3MzAtZWFhMWQzNWUwMzVjLTI",
+									"description": "aasIdentifier as UTF8-BASE64-URL-encoded"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Create new Submodel",
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"endpoints\": [\n    {\n      \"interface\": \"interfaceNameExample\",\n      \"protocolInformation\": {\n        \"href\": \"endpointAddressExample\",\n        \"endpointProtocol\": \"endpointProtocolExample\",\n        \"endpointProtocolVersion\": [\n          \"e\"\n        ],\n        \"subprotocol\": \"subprotocolExample\",\n        \"subprotocolBody\": \"subprotocolBodyExample\",\n        \"subprotocolBodyEncoding\": \"subprotocolBodyExample\",\n        \"securityAttributes\": [\n          {\n            \"type\": \"NONE\"\n          }\n        ]\n      }\n    }\n  ],\n  \"idShort\": \"idShortExample\",\n  \"id\": \"341f63de-728a-4b6d-9c72-c0d9ba4f8c7d\",\n  \"semanticId\": {\n    \"type\": \"ExternalReference\",\n    \"keys\": [\n      {\n        \"type\": \"Submodel\",\n        \"value\": \"semanticIdExample\"\n      }\n    ]\n  },\n  \"description\": [\n    {\n      \"language\": \"de\",\n      \"text\": \"hello text\"\n    },\n    {\n      \"language\": \"en\",\n      \"text\": \"hello s\"\n    }\n  ]\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseUrl}}/api/v3.0/shell-descriptors/:aasIdentifier/submodel-descriptors",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"v3.0",
+								"shell-descriptors",
+								":aasIdentifier",
+								"submodel-descriptors"
+							],
+							"variable": [
+								{
+									"key": "aasIdentifier",
+									"value": "ZTFlYmEzZDctOTFmMC00ZGFjLWE3MzAtZWFhMWQzNWUwMzVjLTI",
+									"description": "aasIdentifier as UTF8-BASE64-URL-encoded"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get Submodel by Id",
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "GET",
+						"header": [
+							{
+								"key": "Edc-Bpn",
+								"value": "",
+								"description": "BPN (This is normally send via EDC)",
+								"type": "default"
+							}
+						],
+						"url": {
+							"raw": "{{baseUrl}}/api/v3.0/shell-descriptors/:aasIdentifier/submodel-descriptors",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"v3.0",
+								"shell-descriptors",
+								":aasIdentifier",
+								"submodel-descriptors"
+							],
+							"query": [
+								{
+									"key": "limit",
+									"value": null,
+									"disabled": true
+								},
+								{
+									"key": "cursor",
+									"value": null,
+									"disabled": true
+								}
+							],
+							"variable": [
+								{
+									"key": "aasIdentifier",
+									"value": "ZTFlYmEzZDctOTFmMC00ZGFjLWE3MzAtZWFhMWQzNWUwMzVjLTI",
+									"description": "aasIdentifier as UTF8-BASE64-URL-encoded"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get specific Submodel by Id",
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "GET",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/api/v3.0/shell-descriptors/:aasIdentifier/submodel-descriptors/:submodelIdentifier",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"v3.0",
+								"shell-descriptors",
+								":aasIdentifier",
+								"submodel-descriptors",
+								":submodelIdentifier"
+							],
+							"variable": [
+								{
+									"key": "aasIdentifier",
+									"value": "ZTFlYmEzZDctOTFmMC00ZGFjLWE3MzAtZWFhMWQzNWUwMzVjLTI",
+									"description": "aasIdentifier as UTF8-BASE64-URL-encoded"
+								},
+								{
+									"key": "submodelIdentifier",
+									"value": "Y2Q0NzYxNWItZGFmMy00MDM2LTg2NzAtZDJmODkzNDlkMzg4LTI=",
+									"description": "submodelIdentifier as UTF8-BASE64-URL-encoded"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Update specific Submodel by Id",
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "PUT",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n  \"endpoints\": [\n    {\n      \"interface\": \"interfaceNameExample\",\n      \"protocolInformation\": {\n        \"href\": \"endpointAddressExample\",\n        \"endpointProtocol\": \"endpointProtocolExample\",\n        \"endpointProtocolVersion\": [\n          \"e\"\n        ],\n        \"subprotocol\": \"subprotocolExample\",\n        \"subprotocolBody\": \"subprotocolBodyExample\",\n        \"subprotocolBodyEncoding\": \"subprotocolBodyExample\",\n        \"securityAttributes\": [\n          {\n            \"type\": \"NONE\"\n          }\n        ]\n      }\n    }\n  ],\n  \"idShort\": \"idShortExample\",\n  \"id\": \"341f63de-728a-4b6d-9c72-c0d9ba4f8c7d\",\n  \"semanticId\": {\n    \"type\": \"ExternalReference\",\n    \"keys\": [\n      {\n        \"type\": \"Submodel\",\n        \"value\": \"semanticIdExample\"\n      }\n    ]\n  },\n  \"description\": [\n    {\n      \"language\": \"de\",\n      \"text\": \"hello text\"\n    },\n    {\n      \"language\": \"en\",\n      \"text\": \"hello s\"\n    }\n  ]\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseUrl}}/api/v3.0/shell-descriptors/:aasIdentifier/submodel-descriptors/:submodelIdentifier",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"v3.0",
+								"shell-descriptors",
+								":aasIdentifier",
+								"submodel-descriptors",
+								":submodelIdentifier"
+							],
+							"variable": [
+								{
+									"key": "aasIdentifier",
+									"value": "ZTFlYmEzZDctOTFmMC00ZGFjLWE3MzAtZWFhMWQzNWUwMzVjLTI",
+									"description": "aasIdentifier as UTF8-BASE64-URL-encoded"
+								},
+								{
+									"key": "submodelIdentifier",
+									"value": "Y2Q0NzYxNWItZGFmMy00MDM2LTg2NzAtZDJmODkzNDlkMzg4LTI=",
+									"description": "submodelIdentifier as UTF8-BASE64-URL-encoded"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Delete specific Submodel by Id",
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "DELETE",
+						"header": [],
+						"url": {
+							"raw": "{{baseUrl}}/api/v3.0/shell-descriptors/:aasIdentifier/submodel-descriptors/:submodelIdentifier",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"v3.0",
+								"shell-descriptors",
+								":aasIdentifier",
+								"submodel-descriptors",
+								":submodelIdentifier"
+							],
+							"variable": [
+								{
+									"key": "aasIdentifier",
+									"value": "ZTFlYmEzZDctOTFmMC00ZGFjLWE3MzAtZWFhMWQzNWUwMzVjLTI",
+									"description": "aasIdentifier as UTF8-BASE64-URL-encoded"
+								},
+								{
+									"key": "submodelIdentifier",
+									"value": "Y2Q0NzYxNWItZGFmMy00MDM2LTg2NzAtZDJmODkzNDlkMzg4LTI=",
+									"description": "submodelIdentifier as UTF8-BASE64-URL-encoded"
+								}
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		},
+		{
+			"name": "Registry and Discovery",
+			"item": [
+				{
+					"name": "Get list of ShellIds (exact match)",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Edc-Bpn",
+								"value": "",
+								"description": "BPN (This is normally send via EDC)",
+								"type": "default"
+							}
+						],
+						"url": {
+							"raw": "{{baseUrl}}/api/v3.0/lookup/shells?assetIds=[{\"name\":\"oen\",\"value\":\"1239485\"},{\"name\":\"manufacturePartId\",\"value\":\"1234\"}]",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"v3.0",
+								"lookup",
+								"shells"
+							],
+							"query": [
+								{
+									"key": "limit",
+									"value": null,
+									"disabled": true
+								},
+								{
+									"key": "cursor",
+									"value": null,
+									"disabled": true
+								},
+								{
+									"key": "assetIds",
+									"value": "[{\"name\":\"oen\",\"value\":\"1239485\"},{\"name\":\"manufacturePartId\",\"value\":\"1234\"}]"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get SpecificAssetIds by aasIdentifier",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Edc-Bpn",
+								"value": "",
+								"description": "BPN (This is normally send via EDC)",
+								"type": "default"
+							}
+						],
+						"url": {
+							"raw": "{{baseUrl}}/api/v3.0/lookup/shells/:aasIdentifier",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"v3.0",
+								"lookup",
+								"shells",
+								":aasIdentifier"
+							],
+							"variable": [
+								{
+									"key": "aasIdentifier",
+									"value": "ZTFlYmEzZDctOTFmMC00ZGFjLWE3MzAtZWFhMWQzNWUwMzVjLTI",
+									"description": "aasIdentifier as UTF8-BASE64-URL-encoded"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Update SpecificAssetIds by aasIdentifier (overwrite existing List)",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Edc-Bpn",
+								"value": "",
+								"description": "BPN (This is normally send via EDC)",
+								"type": "default"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "[\n    {\n      \"name\": \"oen\",\n      \"value\": \"1239485\"\n    }\n  ]",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseUrl}}/api/v3.0/lookup/shells/:aasIdentifier",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"v3.0",
+								"lookup",
+								"shells",
+								":aasIdentifier"
+							],
+							"variable": [
+								{
+									"key": "aasIdentifier",
+									"value": "ZTFlYmEzZDctOTFmMC00ZGFjLWE3MzAtZWFhMWQzNWUwMzVjLTI",
+									"description": "aasIdentifier as UTF8-BASE64-URL-encoded"
+								}
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Get list of ShellIds without encoding",
+					"request": {
+						"method": "POST",
+						"header": [
+							{
+								"key": "Edc-Bpn",
+								"value": "TENANT_ONE",
+								"type": "text"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "[\n    {\n      \"name\": \"manufacturePartId\",\n      \"value\": \"1234\"\n    },\n    {\n      \"name\": \"oen\",\n      \"value\": \"1239485\"\n    },\n    {\n      \"name\": \"serialnr\",\n      \"value\": \"12345\"\n    }\n]   ",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseUrl}}/api/v3.0/lookup/shellsByAssetLink",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"v3.0",
+								"lookup",
+								"shellsByAssetLink"
+							],
+							"query": [
+								{
+									"key": "limit",
+									"value": null,
+									"disabled": true
+								},
+								{
+									"key": "cursor",
+									"value": null,
+									"disabled": true
+								}
+							]
+						}
+					},
+					"response": []
+				}
+			]
+		}
+	],
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	],
+	"variable": [
+		{
+			"key": "baseUrl",
+			"value": "",
+			"type": "default"
+		}
+	]
+}


### PR DESCRIPTION
## Description
New API POST lookup/shellsByAssetLink has been introduced to retrieve Shell IDs without using base 64 encoding.