### PR TITLE
Validation removed for Value field of specificAssetIds

### DIFF
--- a/backend/src/main/resources/static/aas-registry-openapi.yaml
+++ b/backend/src/main/resources/static/aas-registry-openapi.yaml
@@ -1480,7 +1480,7 @@ components:
             value:
               maxLength: 2000
               minLength: 1
-              pattern: "^([\\t\\n\\r \\_\\.\\/\\:\\#\\-a-zA-Z0-9]|[\\ud800\\udc00-\\ud800\\udfff]|[\\ud801\\udc00-\\udbfe\\udfff]|[\\udbff\\udc00-\\udbff\\udfff])*+$"
+#              pattern: "^([\\t\\n\\r \\_\\.\\/\\:\\#\\-a-zA-Z0-9]|[\\ud800\\udc00-\\ud800\\udfff]|[\\ud801\\udc00-\\udbfe\\udfff]|[\\udbff\\udc00-\\udbff\\udfff])*+$"
               type: string
             externalSubjectId:
               $ref: '#/components/schemas/Reference'


### PR DESCRIPTION
 Validation removed for Value field of specificAssetIds while creating shell descriptor

<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->


Few Special characters like + and = should be allowed if a business partner don't want to store the actual value in specific Ids and wants to store those specificAssetIds' values in encoded format then it should work.

This PR fixes the issue: https://github.com/eclipse-tractusx/sldt-digital-twin-registry/issues/391
<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
