### PR TITLE
Bugfix - Triggering Maven Central publish workflow

### DIFF
--- a/.github/workflows/publish-edc-ext-to-maven-central.yml
+++ b/.github/workflows/publish-edc-ext-to-maven-central.yml
@@ -23,7 +23,7 @@
 name: Publish EDC extension to Maven Central
 
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
       tag:
         type: string


### PR DESCRIPTION


<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
- Fixes workflow trigger

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
