### PR TITLE
Bugfix: PUBLIC_READABLE only for defined wildcardAllowedTypes 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## fixed
 - Bugfix access rule management for submodelfilter (visibleSemanticIds): Remove condition on `semanticId.keys.type = submodel` because the `semanticId.keys.type` should be `GlobalReference`. This check is not needed.
 - Implemented mandatory changes in licensing and legal documentation
+- Bugfix: Introduced wildcardAllowedTypes for access management rules. Now, specificAssetIds can only be defined as PUBLIC_READABLE if their types are included in the wildcardAllowedTypes list.
 
 ## 0.4.3
 ### Added

--- a/access-control-service-sql-impl/src/main/java/org/eclipse/tractusx/semantics/accesscontrol/sql/model/AccessRulePolicy.java
+++ b/access-control-service-sql-impl/src/main/java/org/eclipse/tractusx/semantics/accesscontrol/sql/model/AccessRulePolicy.java
@@ -99,4 +99,11 @@ public class AccessRulePolicy {
    private String getAccessRulePolicyValueStringFunction( final AccessRulePolicyValue idValue ) {
       return Optional.ofNullable( idValue ).map( AccessRulePolicyValue::value ).orElse( null );
    }
+
+   @JsonIgnore
+   public void removeVisibleSpecificAssetIdName( String name ) {
+      accessRules.stream()
+            .filter( accessRule -> accessRule.attribute().equals( VISIBLE_SPECIFIC_ASSET_ID_NAMES_RULE_NAME ) )
+            .forEach( accessRule -> accessRule.values().removeIf( id -> id.value().equals( name ) ) );
+   }
 }

--- a/access-control-service-sql-impl/src/test/resources/example-access-rules.json
+++ b/access-control-service-sql-impl/src/test/resources/example-access-rules.json
@@ -20,7 +20,7 @@
             { "attribute": "name", "operator": "eq", "value": "manufacturerPartId" },
             { "attribute": "name", "operator": "eq", "value": "customerPartId" },
             { "attribute": "name", "operator": "eq", "value": "revisionNumber" },
-            { "attribute": "specificAssetIds", "operator": "eq", "value": "partInstanceId" }
+            { "attribute": "name", "operator": "eq", "value": "partInstanceId" }
           ]
         },
         {
@@ -50,7 +50,7 @@
             { "attribute": "name", "operator": "eq", "value": "manufacturerPartId" },
             { "attribute": "name", "operator": "eq", "value": "customerPartId" },
             { "attribute": "name", "operator": "eq", "value": "revisionNumber" },
-            { "attribute": "specificAssetIds", "operator": "eq", "value": "partInstanceId" }
+            { "attribute": "name", "operator": "eq", "value": "partInstanceId" }
           ]
         },
         { "attribute": "visibleSemanticIds", "operator": "includes",
@@ -80,7 +80,7 @@
             { "attribute": "name", "operator": "eq", "value": "manufacturerPartId" },
             { "attribute": "name", "operator": "eq", "value": "customerPartId" },
             { "attribute": "name", "operator": "eq", "value": "versionNumber" },
-            { "attribute": "specificAssetIds", "operator": "eq", "value": "partInstanceId" }
+            { "attribute": "name", "operator": "eq", "value": "partInstanceId" }
           ]
         },
         {
@@ -111,7 +111,7 @@
             { "attribute": "name", "operator": "eq", "value": "manufacturerPartId" },
             { "attribute": "name", "operator": "eq", "value": "customerPartId" },
             { "attribute": "name", "operator": "eq", "value": "versionNumber" },
-            { "attribute": "specificAssetIds", "operator": "eq", "value": "partInstanceId" }
+            { "attribute": "name", "operator": "eq", "value": "partInstanceId" }
           ]
         },
         {
@@ -142,7 +142,7 @@
             { "attribute": "name", "operator": "eq", "value": "manufacturerPartId" },
             { "attribute": "name", "operator": "eq", "value": "customerPartId" },
             { "attribute": "name", "operator": "eq", "value": "versionNumber" },
-            { "attribute": "specificAssetIds", "operator": "eq", "value": "partInstanceId" }
+            { "attribute": "name", "operator": "eq", "value": "partInstanceId" }
           ]
         },
         {

--- a/access-control-service-sql-impl/src/test/resources/example-publicreadable-access-rules.json
+++ b/access-control-service-sql-impl/src/test/resources/example-publicreadable-access-rules.json
@@ -1,0 +1,59 @@
+[
+  {
+    "id": 1, "tid": "BPNL00000000000B", "targetTenant": "PUBLIC_READABLE",
+    "validFrom": "2020-01-02T03:04:05Z", "validTo": "4999-01-02T03:04:05Z",
+    "description": "ACME policy within set validity period",
+    "policyType": "AAS", "policy": {
+    "accessRules": [
+      { "attribute": "bpn", "operator": "eq", "value": "PUBLIC_READABLE" },
+      {
+        "attribute": "mandatorySpecificAssetIds", "operator": "includes",
+        "values": [
+          { "attribute": "manufacturerPartId", "operator": "eq", "value": "99991" },
+          { "attribute": "customerPartId", "operator": "eq", "value": "ACME001" }
+        ]
+      },
+      {
+        "attribute": "visibleSpecificAssetIdNames", "operator": "includes",
+        "values": [
+          { "attribute": "name", "operator": "eq", "value": "manufacturerPartId" },
+          { "attribute": "name", "operator": "eq", "value": "customerPartId" },
+          { "attribute": "name", "operator": "eq", "value": "partInstanceId" }
+        ]
+      },
+      {
+        "attribute": "visibleSemanticIds", "operator": "includes",
+        "values": [ { "attribute": "modelUrn", "operator": "eq", "value": "ProductCarbonFootprintv1.1.0" } ]
+      }
+    ]
+  }
+  },
+  {
+    "id": 2, "tid": "BPNL00000000000B", "targetTenant": "PUBLIC_READABLE",
+    "validFrom": "2020-01-02T03:04:05Z", "validTo": "4999-01-02T03:04:05Z",
+    "description": "ACME policy within set validity period",
+    "policyType": "AAS", "policy": {
+    "accessRules": [
+      { "attribute": "bpn", "operator": "eq", "value": "PUBLIC_READABLE" },
+      {
+        "attribute": "mandatorySpecificAssetIds", "operator": "includes",
+        "values": [
+          { "attribute": "manufacturerPartId", "operator": "eq", "value": "99991" },
+          { "attribute": "revisionNumber", "operator": "eq", "value": "01" }
+        ]
+      },
+      {
+        "attribute": "visibleSpecificAssetIdNames", "operator": "includes",
+        "values": [
+          { "attribute": "name", "operator": "eq", "value": "manufacturerPartId" },
+          { "attribute": "name", "operator": "eq", "value": "revisionNumber" }
+        ]
+      },
+      {
+        "attribute": "visibleSemanticIds", "operator": "includes",
+        "values": [ { "attribute": "modelUrn", "operator": "eq", "value": "ProductCarbonFootprintv1.1.0" } ]
+      }
+    ]
+  }
+  }
+]

--- a/backend/src/main/java/org/eclipse/tractusx/semantics/registry/service/ShellAccessHandlerConfiguration.java
+++ b/backend/src/main/java/org/eclipse/tractusx/semantics/registry/service/ShellAccessHandlerConfiguration.java
@@ -33,7 +33,8 @@ public class ShellAccessHandlerConfiguration {
    @Bean
    public AccessControlRuleService accessControlRuleService(
          final AccessControlRuleRepository accessControlRuleRepository, final RegistryProperties registryProperties ) {
-      return new SqlBackedAccessControlRuleService( accessControlRuleRepository, registryProperties.getExternalSubjectIdWildcardPrefix() );
+      return new SqlBackedAccessControlRuleService( accessControlRuleRepository, registryProperties.getExternalSubjectIdWildcardPrefix(),
+            registryProperties.getExternalSubjectIdWildcardAllowedTypes() );
    }
 
    @Bean

--- a/backend/src/test/java/org/eclipse/tractusx/semantics/registry/GranularAssetAdministrationShellApiSecurityTest.java
+++ b/backend/src/test/java/org/eclipse/tractusx/semantics/registry/GranularAssetAdministrationShellApiSecurityTest.java
@@ -217,7 +217,7 @@ public class GranularAssetAdministrationShellApiSecurityTest extends AssetAdmini
                      // Rule for BPN
                      TestUtil.PUBLIC_READABLE,
                      // Rule for mandatory specificAssetIds
-                     Map.of( keyPrefix + "BPID", "ignoreWildcard", "manufacturerPartId", keyPrefix + "wildcardAllowed" ),
+                     Map.of( "manufacturerPartId", keyPrefix + "wildcardAllowed" ),
                      // Rule for visible specificAssetIds
                      Set.of( "manufacturerPartId" ), Set.of( keyPrefix + "semanticId" ) ),
                TestUtil.createAccessRule(
@@ -418,7 +418,7 @@ public class GranularAssetAdministrationShellApiSecurityTest extends AssetAdmini
       public void testFindExternalShellIdsBySpecificAssetIdsWithTenantBasedVisibilityAndWildcardExpectSuccess() throws Exception {
          accessControlRuleRepository.saveAllAndFlush( List.of(
                TestUtil.createAccessRule( TestUtil.PUBLIC_READABLE,
-                     Map.of( keyPrefix + "bpId", "value_3", "manufacturerPartId", keyPrefix + "value_2" ),
+                     Map.of( "manufacturerPartId", keyPrefix + "value_2" ),
                      Set.of( "manufacturerPartId" ), Set.of( keyPrefix + "semanticId" ) ),
                TestUtil.createAccessRule( jwtTokenFactory.tenantTwo().getTenantId(),
                      Map.of( keyPrefix + "tenantTwo_tenantThree", "value_3", keyPrefix + "tenantTwo", "value_2_private" ),


### PR DESCRIPTION
- Bugfix: Introduced wildcardAllowedTypes for access management rules. Now, specificAssetIds can only be defined as PUBLIC_READABLE if their types are included in the wildcardAllowedTypes list.

<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
