### PR TITLE
Bugfix accessRule: set updatable param to true for tenantTarget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.7.0
+### Added
+## fixed
+- Bugfix: [Updated AccessRule Not Applied: Old BPN Retains Access, New BPN Denied](https://github.com/eclipse-tractusx/sldt-digital-twin-registry/issues/489)
+
 ## 0.6.2
 ### Added
 ## fixed

--- a/access-control-service-sql-impl/src/main/java/org/eclipse/tractusx/semantics/accesscontrol/sql/model/AccessRule.java
+++ b/access-control-service-sql-impl/src/main/java/org/eclipse/tractusx/semantics/accesscontrol/sql/model/AccessRule.java
@@ -66,7 +66,7 @@ public class AccessRule {
 
    @NotNull( groups = { OnCreate.class, OnUpdate.class } )
    @NotBlank( groups = { OnCreate.class, OnUpdate.class } )
-   @Column( name = "TARGET_TENANT", nullable = false, updatable = false, length = 36 )
+   @Column( name = "TARGET_TENANT", nullable = false, length = 36 )
    private String targetTenant;
 
    @NotNull( groups = { OnCreate.class, OnUpdate.class } )


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
Bugfix accessRule: set updatable param to true for tenantTarget
-[Github Issue](https://github.com/eclipse-tractusx/sldt-digital-twin-registry/issues/489)

<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
