### PR TITLE
Fix(Ingress): passthrough tls secret and allow non-prefix paths

### DIFF
--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -53,7 +53,7 @@ jobs:
         with:
           path: ./  # Scan the entire repository
           base: "${{ github.event.repository.default_branch }}"  # Set base branch for comparison (pull requests)
-          extra_args: --filter-entropy=4 --results=verified,unknown --debug
+          extra_args: --filter-entropy=4 --results=verified,unknown --debug --exclude-paths=.thignore
       
       - name: Scan Results Status
         if: steps.trufflehog.outcome == 'failure'

--- a/.thignore
+++ b/.thignore
@@ -1,0 +1,1 @@
+charts/registry/README.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## 0.7.1
+
 ### Added
-## fixed
+
+### Changed
+
+- Allow to not use prefix ingress (ImplementationSpecific)
+
+### Fixed
+
 - Bugfix: removed uniqueness check for idShort validation while shell creation
+- Bugfix: passthrough ingress tls secret
 
 ## 0.7.0
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Allow to not use prefix ingress (ImplementationSpecific)
+- CI: exclude charts/registry/README.md from trufflehog
 
 ### Fixed
 

--- a/DEPENDENCIES
+++ b/DEPENDENCIES
@@ -8,7 +8,7 @@ maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jdk8/2.17.2, 
 maven/mavencentral/com.fasterxml.jackson.datatype/jackson-datatype-jsr310/2.17.2, Apache-2.0, approved, #14160
 maven/mavencentral/com.fasterxml.jackson.module/jackson-module-parameter-names/2.17.2, Apache-2.0, approved, #15122
 maven/mavencentral/com.fasterxml/classmate/1.7.0, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.github.ben-manes.caffeine/caffeine/3.1.8, Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.github.ben-manes.caffeine/caffeine/3.1.8, Apache-2.0 AND (Apache-2.0 AND CC0-1.0), approved, #19704
 maven/mavencentral/com.github.docker-java/docker-java-api/3.3.6, Apache-2.0, approved, #10346
 maven/mavencentral/com.github.docker-java/docker-java-transport-zerodep/3.3.6, Apache-2.0 AND (Apache-2.0 AND BSD-3-Clause), approved, #15251
 maven/mavencentral/com.github.docker-java/docker-java-transport/3.3.6, Apache-2.0, approved, #7942
@@ -22,9 +22,9 @@ maven/mavencentral/com.google.guava/failureaccess/1.0.1, Apache-2.0, approved, C
 maven/mavencentral/com.google.guava/guava/32.1.1-jre, Apache-2.0 AND CC0-1.0 AND LicenseRef-Public-Domain, approved, #9229
 maven/mavencentral/com.google.guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava, Apache-2.0, approved, CQ22657
 maven/mavencentral/com.google.j2objc/j2objc-annotations/2.8, Apache-2.0, approved, clearlydefined
-maven/mavencentral/com.google.protobuf/protobuf-java/3.25.1, BSD-3-Clause, approved, clearlydefined
+maven/mavencentral/com.google.protobuf/protobuf-java/3.25.1, BSD-3-Clause, approved, #19751
 maven/mavencentral/com.h2database/h2/2.2.220, (EPL-1.0 OR MPL-2.0) AND (LGPL-3.0-or-later OR EPL-1.0 OR MPL-2.0), approved, #9322
-maven/mavencentral/com.jayway.jsonpath/json-path/2.9.0, Apache-2.0, approved, clearlydefined
+maven/mavencentral/com.jayway.jsonpath/json-path/2.9.0, Apache-2.0, approved, #20009
 maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.37.3, Apache-2.0, approved, #11701
 maven/mavencentral/com.nimbusds/nimbus-jose-jwt/9.39.1, Apache-2.0, approved, #14830
 maven/mavencentral/com.opencsv/opencsv/5.7.1, Apache-2.0, approved, clearlydefined
@@ -68,25 +68,25 @@ maven/mavencentral/javax.xml.bind/jaxb-api/2.3.1, CDDL-1.1 OR GPL-2.0-only WITH 
 maven/mavencentral/net.bytebuddy/byte-buddy-agent/1.14.19, Apache-2.0, approved, #7164
 maven/mavencentral/net.bytebuddy/byte-buddy/1.14.19, Apache-2.0 AND BSD-3-Clause, approved, #7163
 maven/mavencentral/net.java.dev.jna/jna/5.13.0, Apache-2.0 AND LGPL-2.1-or-later, approved, #15196
-maven/mavencentral/net.minidev/accessors-smart/2.5.1, Apache-2.0, approved, clearlydefined
-maven/mavencentral/net.minidev/json-smart/2.5.1, Apache-2.0, approved, clearlydefined
+maven/mavencentral/net.minidev/accessors-smart/2.5.1, Apache-2.0, approved, #19432
+maven/mavencentral/net.minidev/json-smart/2.5.1, Apache-2.0, approved, #19431
 maven/mavencentral/org.antlr/antlr4-runtime/4.13.0, BSD-3-Clause, approved, #10767
-maven/mavencentral/org.apache.commons/commons-collections4/4.4, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.apache.commons/commons-collections4/4.4, Apache-2.0, approved, #17660
 maven/mavencentral/org.apache.commons/commons-compress/1.24.0, Apache-2.0 AND BSD-3-Clause AND bzip2-1.0.6 AND LicenseRef-Public-Domain, approved, #10368
 maven/mavencentral/org.apache.commons/commons-lang3/3.14.0, Apache-2.0, approved, #11677
 maven/mavencentral/org.apache.commons/commons-text/1.10.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.apache.logging.log4j/log4j-api/2.23.1, Apache-2.0, approved, #13368
 maven/mavencentral/org.apache.logging.log4j/log4j-to-slf4j/2.23.1, Apache-2.0, approved, #15121
 maven/mavencentral/org.apache.tomcat.embed/tomcat-embed-el/10.1.18, Apache-2.0, approved, #6997
-maven/mavencentral/org.apiguardian/apiguardian-api/1.1.2, Apache-2.0, approved, clearlydefined
-maven/mavencentral/org.aspectj/aspectjweaver/1.9.22.1, Apache-2.0 AND BSD-3-Clause AND EPL-1.0 AND BSD-3-Clause AND Apache-1.1, approved, #15252
+maven/mavencentral/org.apiguardian/apiguardian-api/1.1.2, Apache-2.0, approved, #17641
+maven/mavencentral/org.aspectj/aspectjweaver/1.9.22.1, EPL-1.0, approved, tools.aspectj
 maven/mavencentral/org.assertj/assertj-core/3.24.2, Apache-2.0, approved, #6161
 maven/mavencentral/org.awaitility/awaitility/4.2.2, Apache-2.0, approved, #14178
 maven/mavencentral/org.bouncycastle/bcpkix-jdk18on/1.78.1, MIT, approved, #14434
 maven/mavencentral/org.bouncycastle/bcprov-jdk18on/1.78.1, MIT AND CC0-1.0, approved, #14433
 maven/mavencentral/org.bouncycastle/bcutil-jdk18on/1.78.1, MIT, approved, #14435
 maven/mavencentral/org.checkerframework/checker-qual/3.37.0, MIT, approved, clearlydefined
-maven/mavencentral/org.checkerframework/checker-qual/3.42.0, MIT, approved, clearlydefined
+maven/mavencentral/org.checkerframework/checker-qual/3.42.0, MIT, approved, #20003
 maven/mavencentral/org.eclipse.angus/angus-activation/2.0.2, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.angus
 maven/mavencentral/org.eclipse.edc/boot-lib/0.7.0, Apache-2.0, approved, technology.edc
 maven/mavencentral/org.eclipse.edc/boot-spi/0.7.0, Apache-2.0, approved, technology.edc
@@ -154,11 +154,11 @@ maven/mavencentral/org.glassfish.jaxb/txw2/4.0.5, BSD-3-Clause, approved, ee4j.j
 maven/mavencentral/org.glassfish.jersey.core/jersey-common/3.1.9, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
 maven/mavencentral/org.glassfish.jersey.core/jersey-server/3.1.9, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jersey
 maven/mavencentral/org.glassfish/jakarta.json/2.0.1, EPL-2.0 OR GPL-2.0-only with Classpath-exception-2.0, approved, ee4j.jsonp
-maven/mavencentral/org.hamcrest/hamcrest/2.2, BSD-3-Clause, approved, clearlydefined
+maven/mavencentral/org.hamcrest/hamcrest/2.2, BSD-3-Clause, approved, #17677
 maven/mavencentral/org.hdrhistogram/HdrHistogram/2.2.2, BSD-2-Clause AND CC0-1.0 AND CC0-1.0, approved, #14828
 maven/mavencentral/org.hibernate.common/hibernate-commons-annotations/6.0.6.Final, LGPL-2.1-only, approved, #6962
 maven/mavencentral/org.hibernate.orm/hibernate-core/6.5.3.Final, LGPL-2.1-only AND (EPL-2.0 OR BSD-3-Clause) AND LGPL-2.1-or-later AND MIT, approved, #15118
-maven/mavencentral/org.hibernate.validator/hibernate-validator/8.0.1.Final, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.hibernate.validator/hibernate-validator/8.0.1.Final, Apache-2.0 AND CC-PDDC, approved, #18198
 maven/mavencentral/org.jboss.logging/jboss-logging/3.5.3.Final, Apache-2.0, approved, #9471
 maven/mavencentral/org.jetbrains.kotlin/kotlin-stdlib-common/1.9.25, Apache-2.0, approved, #14186
 maven/mavencentral/org.jetbrains.kotlin/kotlin-stdlib-jdk7/1.9.25, Apache-2.0, approved, #14188
@@ -178,7 +178,7 @@ maven/mavencentral/org.liquibase/liquibase-core/4.19.1, Apache-2.0, approved, cl
 maven/mavencentral/org.mapstruct/mapstruct/1.5.3.Final, Apache-2.0, approved, #6277
 maven/mavencentral/org.mockito/mockito-core/5.11.0, MIT AND (Apache-2.0 AND MIT) AND Apache-2.0, approved, #13505
 maven/mavencentral/org.mockito/mockito-junit-jupiter/5.11.0, MIT, approved, #13504
-maven/mavencentral/org.objenesis/objenesis/3.3, Apache-2.0, approved, clearlydefined
+maven/mavencentral/org.objenesis/objenesis/3.3, Apache-2.0, approved, #19727
 maven/mavencentral/org.openapitools/jackson-databind-nullable/0.1.0, Apache-2.0, approved, clearlydefined
 maven/mavencentral/org.opentest4j/opentest4j/1.3.0, Apache-2.0, approved, #9713
 maven/mavencentral/org.ow2.asm/asm-commons/9.7, BSD-3-Clause, approved, #16465

--- a/charts/registry/Chart.yaml
+++ b/charts/registry/Chart.yaml
@@ -26,8 +26,8 @@ sources:
   - https://github.com/eclipse-tractusx/sldt-digital-twin-registry
 
 type: application
-version: 0.7.1
-appVersion: 0.7.1
+version: 0.7.0
+appVersion: 0.7.0
 
 dependencies:
   - repository: https://charts.bitnami.com/bitnami

--- a/charts/registry/Chart.yaml
+++ b/charts/registry/Chart.yaml
@@ -26,8 +26,8 @@ sources:
   - https://github.com/eclipse-tractusx/sldt-digital-twin-registry
 
 type: application
-version: 0.7.0
-appVersion: 0.7.0
+version: 0.7.1
+appVersion: 0.7.1
 
 dependencies:
   - repository: https://charts.bitnami.com/bitnami

--- a/charts/registry/Chart.yaml
+++ b/charts/registry/Chart.yaml
@@ -26,7 +26,7 @@ sources:
   - https://github.com/eclipse-tractusx/sldt-digital-twin-registry
 
 type: application
-version: 0.7.0
+version: 0.7.1
 appVersion: 0.7.0
 
 dependencies:

--- a/charts/registry/README.md
+++ b/charts/registry/README.md
@@ -1,6 +1,6 @@
 # digital-twin-registry
 
-![Version: 0.7.1](https://img.shields.io/badge/Version-0.7.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.1](https://img.shields.io/badge/AppVersion-0.7.1-informational?style=flat-square)
+![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.0](https://img.shields.io/badge/AppVersion-0.7.0-informational?style=flat-square)
 
 Tractus-X Digital Twin Registry Helm Chart
 
@@ -41,7 +41,7 @@ To use the helm chart as a dependency:
 
 ```yaml
 dependencies:
-  - name: puris
+  - name: registry
     repository: https://eclipse-tractusx.github.io/charts/dev
     version: YOUR_VERSION
 ```
@@ -57,78 +57,78 @@ helm install registry -n semantics . --create-namespace
 
 ## Values
 
-| Key                                               | Type   | Default                                                                                                                                                        | Description                                      |
-|---------------------------------------------------|--------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------|
-| enableKeycloak                                    | bool   | `false`                                                                                                                                                        |                                                  |
-| enablePostgres                                    | bool   | `true`                                                                                                                                                         |                                                  |
-| fullnameOverride                                  | string | `nil`                                                                                                                                                          |                                                  |
-| keycloak.args[0]                                  | string | `"kc.sh import --file /opt/keycloak/data/import/default-realm-import.json; kc.sh start-dev --hostname=registry-keycloak --hostname-strict=false --proxy=edge"` |                                                  |
-| keycloak.auth.adminPassword                       | string | `nil`                                                                                                                                                          |                                                  |
-| keycloak.auth.adminUser                           | string | `nil`                                                                                                                                                          |                                                  |
-| keycloak.command[0]                               | string | `"/bin/sh"`                                                                                                                                                    |                                                  |
-| keycloak.command[1]                               | string | `"-c"`                                                                                                                                                         |                                                  |
-| keycloak.externalDatabase.existingSecret          | string | `"keycloak-database-credentials"`                                                                                                                              |                                                  |
-| keycloak.extraVolumeMounts[0].mountPath           | string | `"/opt/keycloak/data/import/default-realm-import.json"`                                                                                                        |                                                  |
-| keycloak.extraVolumeMounts[0].name                | string | `"registry-keycloak-configmap"`                                                                                                                                |                                                  |
-| keycloak.extraVolumeMounts[0].subPath             | string | `"default-realm-import.json"`                                                                                                                                  |                                                  |
-| keycloak.extraVolumes[0].configMap.name           | string | `"registry-keycloak-configmap"`                                                                                                                                |                                                  |
-| keycloak.extraVolumes[0].name                     | string | `"registry-keycloak-configmap"`                                                                                                                                |                                                  |
-| keycloak.fullnameOverride                         | string | `"registry-keycloak"`                                                                                                                                          |                                                  |
-| keycloak.postgresql.enabled                       | bool   | `false`                                                                                                                                                        |                                                  |
-| keycloak.service.type                             | string | `"ClusterIP"`                                                                                                                                                  |                                                  |
-| nameOverride                                      | string | `nil`                                                                                                                                                          |                                                  |
-| postgresql.auth.database                          | string | `"default-database"`                                                                                                                                           |                                                  |
-| postgresql.auth.existingSecret                    | string | `"secret-dtr-postgres-init"`                                                                                                                                   | Secret contains passwords for username postgres. |
-| postgresql.auth.password                          | string | `nil`                                                                                                                                                          |                                                  |
-| postgresql.auth.username                          | string | `"default-user"`                                                                                                                                               |                                                  |
-| postgresql.primary.persistence.enabled            | bool   | `true`                                                                                                                                                         |                                                  |
-| postgresql.primary.persistence.size               | string | `"50Gi"`                                                                                                                                                       |                                                  |
-| postgresql.service.ports.postgresql               | int    | `5432`                                                                                                                                                         |                                                  |
-| registry.authentication                           | bool   | `true`                                                                                                                                                         |                                                  |
-| registry.containerPort                            | int    | `4243`                                                                                                                                                         |                                                  |
-| registry.dataSource.driverClassName               | string | `"org.postgresql.Driver"`                                                                                                                                      |                                                  |
-| registry.dataSource.password                      | string | `nil`                                                                                                                                                          |                                                  |
-| registry.dataSource.sqlInitPlatform               | string | `"pg"`                                                                                                                                                         |                                                  |
-| registry.dataSource.url                           | string | `"jdbc:postgresql://database:5432"`                                                                                                                            |                                                  |
-| registry.dataSource.user                          | string | `"default-user"`                                                                                                                                               |                                                  |
-| registry.externalSubjectIdWildcardAllowedTypes    | string | `"manufacturerPartId,digitalTwinType"`                                                                                                                         |                                                  |
-| registry.externalSubjectIdWildcardPrefix          | string | `"PUBLIC_READABLE"`                                                                                                                                            |                                                  |
-| registry.granularAccessControlFetchSize           | string | `"500"`                                                                                                                                                        |                                                  |
-| registry.host                                     | string | `"minikube"`                                                                                                                                                   |                                                  |
-| registry.identityProvider                         | string | `"keycloak"`                                                                                                                                                   |                                                  |
-| registry.idpClientId                              | string | `"default-client"`                                                                                                                                             |                                                  |
-| registry.idpInternalClientId                      | string | `"default-client"`                                                                                                                                             |                                                  |
-| registry.idpIssuerUri                             | string | `""`                                                                                                                                                           |                                                  |
-| registry.image.registry                           | string | `"docker.io"`                                                                                                                                                  |                                                  |
-| registry.image.repository                         | string | `"tractusx/sldt-digital-twin-registry"`                                                                                                                        |                                                  |
-| registry.image.version                            | string | `""`                                                                                                                                                           |                                                  |
-| registry.imagePullPolicy                          | string | `"IfNotPresent"`                                                                                                                                               |                                                  |
-| registry.ingress.annotations                      | object | `{}`                                                                                                                                                           |                                                  |
-| registry.ingress.className                        | string | `"nginx"`                                                                                                                                                      |                                                  |
-| registry.ingress.enabled                          | bool   | `true`                                                                                                                                                         |                                                  |
-| registry.ingress.rules                            | list   | `[]`                                                                                                                                                           |                                                  |
-| registry.ingress.tls.enabled                      | bool   | `true`                                                                                                                                                         |                                                  |
-| registry.ingress.tls.secretName                   | string | `"registry-certificate-secret"`                                                                                                                                |                                                  |
-| registry.ingress.urlPrefix                        | string | `"/semantics/registry"`                                                                                                                                        |                                                  |
-| registry.livenessProbe.failureThreshold           | int    | `3`                                                                                                                                                            |                                                  |
-| registry.livenessProbe.initialDelaySeconds        | int    | `100`                                                                                                                                                          |                                                  |
-| registry.livenessProbe.periodSeconds              | int    | `3`                                                                                                                                                            |                                                  |
-| registry.podSecurityContext.runAsUser             | int    | `100`                                                                                                                                                          |                                                  |
-| registry.readinessProbe.failureThreshold          | int    | `3`                                                                                                                                                            |                                                  |
-| registry.readinessProbe.initialDelaySeconds       | int    | `100`                                                                                                                                                          |                                                  |
-| registry.readinessProbe.periodSeconds             | int    | `3`                                                                                                                                                            |                                                  |
-| registry.replicaCount                             | int    | `1`                                                                                                                                                            |                                                  |
-| registry.resources.limits.cpu                     | string | `"750m"`                                                                                                                                                       |                                                  |
-| registry.resources.limits.memory                  | string | `"1024Mi"`                                                                                                                                                     |                                                  |
-| registry.resources.requests.cpu                   | string | `"250m"`                                                                                                                                                       |                                                  |
-| registry.resources.requests.memory                | string | `"1024Mi"`                                                                                                                                                     |                                                  |
-| registry.securityContext.allowPrivilegeEscalation | bool   | `false`                                                                                                                                                        |                                                  |
-| registry.securityContext.readOnlyRootFilesystem   | bool   | `true`                                                                                                                                                         |                                                  |
-| registry.securityContext.runAsUser                | int    | `100`                                                                                                                                                          |                                                  |
-| registry.service.port                             | int    | `8080`                                                                                                                                                         |                                                  |
-| registry.service.type                             | string | `"ClusterIP"`                                                                                                                                                  |                                                  |
-| registry.tenantId                                 | string | `"default-tenant"`                                                                                                                                             |                                                  |
-| registry.useGranularAccessControl                 | string | `"false"`                                                                                                                                                      |                                                  |
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| enableKeycloak | bool | `false` |  |
+| enablePostgres | bool | `true` |  |
+| fullnameOverride | string | `nil` |  |
+| keycloak.args[0] | string | `"kc.sh import --file /opt/keycloak/data/import/default-realm-import.json; kc.sh start-dev --hostname=registry-keycloak --hostname-strict=false --proxy=edge"` |  |
+| keycloak.auth.adminPassword | string | `nil` |  |
+| keycloak.auth.adminUser | string | `nil` |  |
+| keycloak.command[0] | string | `"/bin/sh"` |  |
+| keycloak.command[1] | string | `"-c"` |  |
+| keycloak.externalDatabase.existingSecret | string | `"keycloak-database-credentials"` |  |
+| keycloak.extraVolumeMounts[0].mountPath | string | `"/opt/keycloak/data/import/default-realm-import.json"` |  |
+| keycloak.extraVolumeMounts[0].name | string | `"registry-keycloak-configmap"` |  |
+| keycloak.extraVolumeMounts[0].subPath | string | `"default-realm-import.json"` |  |
+| keycloak.extraVolumes[0].configMap.name | string | `"registry-keycloak-configmap"` |  |
+| keycloak.extraVolumes[0].name | string | `"registry-keycloak-configmap"` |  |
+| keycloak.fullnameOverride | string | `"registry-keycloak"` |  |
+| keycloak.postgresql.enabled | bool | `false` |  |
+| keycloak.service.type | string | `"ClusterIP"` |  |
+| nameOverride | string | `nil` |  |
+| postgresql.auth.database | string | `"default-database"` |  |
+| postgresql.auth.existingSecret | string | `"secret-dtr-postgres-init"` | Secret contains passwords for username postgres. |
+| postgresql.auth.password | string | `nil` |  |
+| postgresql.auth.username | string | `"default-user"` |  |
+| postgresql.primary.persistence.enabled | bool | `true` |  |
+| postgresql.primary.persistence.size | string | `"50Gi"` |  |
+| postgresql.service.ports.postgresql | int | `5432` |  |
+| registry.authentication | bool | `true` |  |
+| registry.containerPort | int | `4243` |  |
+| registry.dataSource.driverClassName | string | `"org.postgresql.Driver"` |  |
+| registry.dataSource.password | string | `nil` |  |
+| registry.dataSource.sqlInitPlatform | string | `"pg"` |  |
+| registry.dataSource.url | string | `"jdbc:postgresql://database:5432"` |  |
+| registry.dataSource.user | string | `"default-user"` |  |
+| registry.externalSubjectIdWildcardAllowedTypes | string | `"manufacturerPartId,digitalTwinType"` |  |
+| registry.externalSubjectIdWildcardPrefix | string | `"PUBLIC_READABLE"` |  |
+| registry.granularAccessControlFetchSize | string | `"500"` |  |
+| registry.host | string | `"minikube"` |  |
+| registry.identityProvider | string | `"keycloak"` |  |
+| registry.idpClientId | string | `"default-client"` |  |
+| registry.idpInternalClientId | string | `"default-client"` |  |
+| registry.idpIssuerUri | string | `""` |  |
+| registry.image.registry | string | `"docker.io"` |  |
+| registry.image.repository | string | `"tractusx/sldt-digital-twin-registry"` |  |
+| registry.image.version | string | `""` |  |
+| registry.imagePullPolicy | string | `"IfNotPresent"` |  |
+| registry.ingress.annotations | object | `{}` |  |
+| registry.ingress.className | string | `"nginx"` |  |
+| registry.ingress.enabled | bool | `true` |  |
+| registry.ingress.rules | list | `[]` |  |
+| registry.ingress.tls.enabled | bool | `true` |  |
+| registry.ingress.tls.secretName | string | `"registry-certificate-secret"` |  |
+| registry.ingress.urlPrefix | string | `"/semantics/registry"` |  |
+| registry.livenessProbe.failureThreshold | int | `3` |  |
+| registry.livenessProbe.initialDelaySeconds | int | `100` |  |
+| registry.livenessProbe.periodSeconds | int | `3` |  |
+| registry.podSecurityContext.runAsUser | int | `100` |  |
+| registry.readinessProbe.failureThreshold | int | `3` |  |
+| registry.readinessProbe.initialDelaySeconds | int | `100` |  |
+| registry.readinessProbe.periodSeconds | int | `3` |  |
+| registry.replicaCount | int | `1` |  |
+| registry.resources.limits.cpu | string | `"750m"` |  |
+| registry.resources.limits.memory | string | `"1024Mi"` |  |
+| registry.resources.requests.cpu | string | `"250m"` |  |
+| registry.resources.requests.memory | string | `"1024Mi"` |  |
+| registry.securityContext.allowPrivilegeEscalation | bool | `false` |  |
+| registry.securityContext.readOnlyRootFilesystem | bool | `true` |  |
+| registry.securityContext.runAsUser | int | `100` |  |
+| registry.service.port | int | `8080` |  |
+| registry.service.type | string | `"ClusterIP"` |  |
+| registry.tenantId | string | `"default-tenant"` |  |
+| registry.useGranularAccessControl | string | `"false"` |  |
 
 ----------------------------------------------
 Autogenerated from chart metadata using [helm-docs v1.11.3](https://github.com/norwoodj/helm-docs/releases/v1.11.3)

--- a/charts/registry/README.md
+++ b/charts/registry/README.md
@@ -1,6 +1,6 @@
 # digital-twin-registry
 
-![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.0](https://img.shields.io/badge/AppVersion-0.7.0-informational?style=flat-square)
+![Version: 0.7.1](https://img.shields.io/badge/Version-0.7.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.0](https://img.shields.io/badge/AppVersion-0.7.0-informational?style=flat-square)
 
 Tractus-X Digital Twin Registry Helm Chart
 

--- a/charts/registry/README.md
+++ b/charts/registry/README.md
@@ -1,96 +1,142 @@
-# registry
+# digital-twin-registry
 
-![Version: 0.7.0](https://img.shields.io/badge/Version-0.7.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.0](https://img.shields.io/badge/AppVersion-0.7.0-informational?style=flat-square)
+![Version: 0.7.1](https://img.shields.io/badge/Version-0.7.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.7.1](https://img.shields.io/badge/AppVersion-0.7.1-informational?style=flat-square)
 
-**Tractus-X Digital Twin Registry Helm Chart**<br/>
-This Helm charts install the Digital Twin Registry and its dependencies.
+Tractus-X Digital Twin Registry Helm Chart
+
+**Homepage:** <https://eclipse-tractusx.github.io/>
+
+## Source Code
+
+* <https://github.com/eclipse-tractusx/sldt-digital-twin-registry>
 
 ## Requirements
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | keycloak | 13.3.0 |
-| https://charts.bitnami.com/bitnami | postgresql | 12.1.7 |
+| https://charts.bitnami.com/bitnami | keycloak | 16.1.7 |
+| https://charts.bitnami.com/bitnami | postgresql | 12.12.10 |
 
 ## Prerequisites
+
 - Kubernetes 1.19+
 - Helm 3.2.0+
 - PV provisioner support in the underlying infrastructure
 
 ## Install
+
+To install the chart with the release name `registry`:
+
+```shell
+$ helm repo add tractusx-dev https://eclipse-tractusx.github.io/charts/dev
+$ helm install registry tractusx-dev/registry
 ```
-helm dep up charts/registry
+To install the helm chart into your cluster with your values:
 
-kubectl create namespace semantics
-
-helm install registry -n semantics charts/registry
-
+```shell
+$ helm install -f your-values.yaml registry tractusx-dev/registry
 ```
 
+To use the helm chart as a dependency:
+
+```yaml
+dependencies:
+  - name: puris
+    repository: https://eclipse-tractusx.github.io/charts/dev
+    version: YOUR_VERSION
+```
+
+To install the local version in the namespace _semantics_:
+
+```shell
+
+helm dependency update .
+
+helm install registry -n semantics . --create-namespace
+```
 
 ## Values
 
-| Key                                            | Type   | Default                                                                                                                                                       | Description                                                                                 |
-|------------------------------------------------|--------|---------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------|
-| enableKeycloak                                 | bool   | `true`                                                                                                                                                        |                                                                                             |
-| enablePostgres                                 | bool   | `true`                                                                                                                                                        |                                                                                             |
-| keycloak.args[0]                               | string | `"kc.sh import --file /opt/keycloak/data/import/default-realm-import.json; kc.sh start-dev --hostname=registry-keycloak --hostname-strict=false --proxy=edge"` |                                                                                             |
-| keycloak.auth.adminPassword                    | string | `"admin"`                                                                                                                                                     |                                                                                             |
-| keycloak.auth.adminUser                        | string | `"admin"`                                                                                                                                                     |                                                                                             |
-| keycloak.command[0]                            | string | `"/bin/sh"`                                                                                                                                                   |                                                                                             |
-| keycloak.command[1]                            | string | `"-c"`                                                                                                                                                        |                                                                                             |
-| keycloak.externalDatabase.existingSecret       | string | `"keycloak-database-credentials"`                                                                                                                             |                                                                                             |
-| keycloak.extraVolumeMounts[0].mountPath        | string | `"/opt/keycloak/data/import/default-realm-import.json"`                                                                                                       |                                                                                             |
-| keycloak.extraVolumeMounts[0].name             | string | `"registry-keycloak-configmap"`                                                                                                                               | default is "{{ .Values.keycloak.fullnameOverride }}-configmap"                              |
-| keycloak.extraVolumeMounts[0].subPath          | string | `"default-realm-import.json"`                                                                                                                                 |                                                                                             |
-| keycloak.extraVolumes[0].configMap.name        | string | `"registry-keycloak-configmap"`                                                                                                                                           | default is "{{ .Values.keycloak.fullnameOverride }}-configmap"                                                                                            |
-| keycloak.extraVolumes[0].name                  | string | `"registry-keycloak-configmap"`                                                                                                                                           | default is "{{ .Values.keycloak.fullnameOverride }}-configmap"                                                                                            |
-| keycloak.fullnameOverride                      | string | `"registry-keycloak"`                                                                                                                                         |                                                                                             |
-| keycloak.postgresql.enabled                    | bool   | `false`                                                                                                                                                       |                                                                                             |
-| keycloak.service.type                          | string | `"ClusterIP"`                                                                                                                                                 |                                                                                             |
-| postgresql.auth.database                       | string | `"default-database"`                                                                                                                                          |                                                                                             |
-| postgresql.auth.password                       | string | `"password"`                                                                                                                                                  |                                                                                             |
-| postgresql.auth.username                       | string | `"default-user"`                                                                                                                                              |                                                                                             |
-| postgresql.primary.persistence.enabled         | bool   | `true`                                                                                                                                                        |                                                                                             |
-| postgresql.primary.persistence.size            | string | `"50Gi"`                                                                                                                                                      |                                                                                             |
-| postgresql.service.ports.postgresql            | int    | `5432`                                                                                                                                                        |                                                                                             |
-| registry.authentication                        | bool   | `true`                                                                                                                                                        |                                                                                             |
-| registry.containerPort                         | int    | `4243`                                                                                                                                                        |                                                                                             |
-| registry.dataSource.driverClassName            | string | `"org.postgresql.Driver"`                                                                                                                                     |                                                                                             |
-| registry.dataSource.password                   | string | `""`                                                                                                                                                          |                                                                                             |
-| registry.dataSource.sqlInitPlatform            | string | `"pg"`                                                                                                                                                        |                                                                                             |
-| registry.dataSource.url                        | string | `"jdbc:postgresql://database:5432"`                                                                                                                           |                                                                                             |
-| registry.dataSource.user                       | string | `"default-user"`                                                                                                                                              |                                                                                             |
-| registry.host                                  | string | `"minikube"`                                                                                                                                                  |                                                                                             |
-| registry.identityProvider                      | string | `"keycloak"`                                                                                                                                                  |                                                                                             |
-| registry.idpClientId                           | string | `"default-client"`                                                                                                                                            |                                                                                             |
-| registry.idpInternalClientId                   | string | `"default-client"`                                                                                                                                            |                                                                                             |
-| registry.idpIssuerUri                          | string | `""`                                                                                                                                                          |                                                                                             |
-| registry.image.registry                        | string | `"docker.io"`                                                                                                                                                 |                                                                                             |
-| registry.image.repository                      | string | `"tractusx/sldt-digital-twin-registry"`                                                                                                                       |                                                                                             |
-| registry.image.version                         | string | `""`                                                                                                                                                          |                                                                                             |
-| registry.imagePullPolicy                       | string | `"IfNotPresent"`                                                                                                                                              |                                                                                             |
-| registry.ingress.annotations                   | object | `{}`                                                                                                                                                          |                                                                                             |
-| registry.ingress.className                     | string | `"nginx"`                                                                                                                                                     |                                                                                             |
-| registry.ingress.enabled                       | bool   | `false`                                                                                                                                                       |                                                                                             |
-| registry.ingress.tls                           | bool   | `false`                                                                                                                                                       |                                                                                             |
-| registry.ingress.urlPrefix                     | string | `"/semantics/registry"`                                                                                                                                       |                                                                                             |
-| registry.replicaCount                          | int    | `1`                                                                                                                                                           |                                                                                             |
-| registry.resources.limits.memory               | string | `"1024Mi"`                                                                                                                                                    |                                                                                             |
-| registry.resources.requests.memory             | string | `"512Mi"`                                                                                                                                                     |                                                                                             |
-| registry.service.port                          | int    | `8080`                                                                                                                                                        |                                                                                             |
-| registry.service.type                          | string | `"ClusterIP"`                                                                                                                                                 |                                                                                             |
-| registry.tenantId                              | string | `"default-tenant"`                                                                                                                                            |                                                                                             |
-| registry.externalSubjectIdWildcardPrefix       | string | `PUBLIC_READABLE`                                                                                                                                             |                                                                                             |
-| registry.externalSubjectIdWildcardAllowedTypes | string | `manufacturerPartId,assetLifecyclePhase`                                                                                                                      |                                                                                             |
-| registry.livenessProbe.initialDelaySeconds     | int    | `100`                                                                                                                                                         |                                                                                             |
-| registry.livenessProbe.failureThreshold        | int    | `3`                                                                                                                                                           |                                                                                             |
-| registry.livenessProbe.periodSeconds           | int    | `3`                                                                                                                                                           |                                                                                             |
-| registry.readinessProbe.initialDelaySeconds    | int    | `100`                                                                                                                                                         |                                                                                             |
-| registry.readinessProbe.failureThreshold       | int    | `3`                                                                                                                                                           |                                                                                             |
-| registry.readinessProbe.periodSeconds          | int    | `3`                                                                                                                                                           |                                                                                             |
-| registry.useGranularAccessControl              | string | `"true"`                                                                                                                                                      | Turns the granular access control on/off.                                                   |
-| registry.granularAccessControlFetchSize        | string | `"500"`                                                                                                                                                       | Defines how many records should be fetched in one query when using granular access control. |
+| Key                                               | Type   | Default                                                                                                                                                        | Description                                      |
+|---------------------------------------------------|--------|----------------------------------------------------------------------------------------------------------------------------------------------------------------|--------------------------------------------------|
+| enableKeycloak                                    | bool   | `false`                                                                                                                                                        |                                                  |
+| enablePostgres                                    | bool   | `true`                                                                                                                                                         |                                                  |
+| fullnameOverride                                  | string | `nil`                                                                                                                                                          |                                                  |
+| keycloak.args[0]                                  | string | `"kc.sh import --file /opt/keycloak/data/import/default-realm-import.json; kc.sh start-dev --hostname=registry-keycloak --hostname-strict=false --proxy=edge"` |                                                  |
+| keycloak.auth.adminPassword                       | string | `nil`                                                                                                                                                          |                                                  |
+| keycloak.auth.adminUser                           | string | `nil`                                                                                                                                                          |                                                  |
+| keycloak.command[0]                               | string | `"/bin/sh"`                                                                                                                                                    |                                                  |
+| keycloak.command[1]                               | string | `"-c"`                                                                                                                                                         |                                                  |
+| keycloak.externalDatabase.existingSecret          | string | `"keycloak-database-credentials"`                                                                                                                              |                                                  |
+| keycloak.extraVolumeMounts[0].mountPath           | string | `"/opt/keycloak/data/import/default-realm-import.json"`                                                                                                        |                                                  |
+| keycloak.extraVolumeMounts[0].name                | string | `"registry-keycloak-configmap"`                                                                                                                                |                                                  |
+| keycloak.extraVolumeMounts[0].subPath             | string | `"default-realm-import.json"`                                                                                                                                  |                                                  |
+| keycloak.extraVolumes[0].configMap.name           | string | `"registry-keycloak-configmap"`                                                                                                                                |                                                  |
+| keycloak.extraVolumes[0].name                     | string | `"registry-keycloak-configmap"`                                                                                                                                |                                                  |
+| keycloak.fullnameOverride                         | string | `"registry-keycloak"`                                                                                                                                          |                                                  |
+| keycloak.postgresql.enabled                       | bool   | `false`                                                                                                                                                        |                                                  |
+| keycloak.service.type                             | string | `"ClusterIP"`                                                                                                                                                  |                                                  |
+| nameOverride                                      | string | `nil`                                                                                                                                                          |                                                  |
+| postgresql.auth.database                          | string | `"default-database"`                                                                                                                                           |                                                  |
+| postgresql.auth.existingSecret                    | string | `"secret-dtr-postgres-init"`                                                                                                                                   | Secret contains passwords for username postgres. |
+| postgresql.auth.password                          | string | `nil`                                                                                                                                                          |                                                  |
+| postgresql.auth.username                          | string | `"default-user"`                                                                                                                                               |                                                  |
+| postgresql.primary.persistence.enabled            | bool   | `true`                                                                                                                                                         |                                                  |
+| postgresql.primary.persistence.size               | string | `"50Gi"`                                                                                                                                                       |                                                  |
+| postgresql.service.ports.postgresql               | int    | `5432`                                                                                                                                                         |                                                  |
+| registry.authentication                           | bool   | `true`                                                                                                                                                         |                                                  |
+| registry.containerPort                            | int    | `4243`                                                                                                                                                         |                                                  |
+| registry.dataSource.driverClassName               | string | `"org.postgresql.Driver"`                                                                                                                                      |                                                  |
+| registry.dataSource.password                      | string | `nil`                                                                                                                                                          |                                                  |
+| registry.dataSource.sqlInitPlatform               | string | `"pg"`                                                                                                                                                         |                                                  |
+| registry.dataSource.url                           | string | `"jdbc:postgresql://database:5432"`                                                                                                                            |                                                  |
+| registry.dataSource.user                          | string | `"default-user"`                                                                                                                                               |                                                  |
+| registry.externalSubjectIdWildcardAllowedTypes    | string | `"manufacturerPartId,digitalTwinType"`                                                                                                                         |                                                  |
+| registry.externalSubjectIdWildcardPrefix          | string | `"PUBLIC_READABLE"`                                                                                                                                            |                                                  |
+| registry.granularAccessControlFetchSize           | string | `"500"`                                                                                                                                                        |                                                  |
+| registry.host                                     | string | `"minikube"`                                                                                                                                                   |                                                  |
+| registry.identityProvider                         | string | `"keycloak"`                                                                                                                                                   |                                                  |
+| registry.idpClientId                              | string | `"default-client"`                                                                                                                                             |                                                  |
+| registry.idpInternalClientId                      | string | `"default-client"`                                                                                                                                             |                                                  |
+| registry.idpIssuerUri                             | string | `""`                                                                                                                                                           |                                                  |
+| registry.image.registry                           | string | `"docker.io"`                                                                                                                                                  |                                                  |
+| registry.image.repository                         | string | `"tractusx/sldt-digital-twin-registry"`                                                                                                                        |                                                  |
+| registry.image.version                            | string | `""`                                                                                                                                                           |                                                  |
+| registry.imagePullPolicy                          | string | `"IfNotPresent"`                                                                                                                                               |                                                  |
+| registry.ingress.annotations                      | object | `{}`                                                                                                                                                           |                                                  |
+| registry.ingress.className                        | string | `"nginx"`                                                                                                                                                      |                                                  |
+| registry.ingress.enabled                          | bool   | `true`                                                                                                                                                         |                                                  |
+| registry.ingress.rules                            | list   | `[]`                                                                                                                                                           |                                                  |
+| registry.ingress.tls.enabled                      | bool   | `true`                                                                                                                                                         |                                                  |
+| registry.ingress.tls.secretName                   | string | `"registry-certificate-secret"`                                                                                                                                |                                                  |
+| registry.ingress.urlPrefix                        | string | `"/semantics/registry"`                                                                                                                                        |                                                  |
+| registry.livenessProbe.failureThreshold           | int    | `3`                                                                                                                                                            |                                                  |
+| registry.livenessProbe.initialDelaySeconds        | int    | `100`                                                                                                                                                          |                                                  |
+| registry.livenessProbe.periodSeconds              | int    | `3`                                                                                                                                                            |                                                  |
+| registry.podSecurityContext.runAsUser             | int    | `100`                                                                                                                                                          |                                                  |
+| registry.readinessProbe.failureThreshold          | int    | `3`                                                                                                                                                            |                                                  |
+| registry.readinessProbe.initialDelaySeconds       | int    | `100`                                                                                                                                                          |                                                  |
+| registry.readinessProbe.periodSeconds             | int    | `3`                                                                                                                                                            |                                                  |
+| registry.replicaCount                             | int    | `1`                                                                                                                                                            |                                                  |
+| registry.resources.limits.cpu                     | string | `"750m"`                                                                                                                                                       |                                                  |
+| registry.resources.limits.memory                  | string | `"1024Mi"`                                                                                                                                                     |                                                  |
+| registry.resources.requests.cpu                   | string | `"250m"`                                                                                                                                                       |                                                  |
+| registry.resources.requests.memory                | string | `"1024Mi"`                                                                                                                                                     |                                                  |
+| registry.securityContext.allowPrivilegeEscalation | bool   | `false`                                                                                                                                                        |                                                  |
+| registry.securityContext.readOnlyRootFilesystem   | bool   | `true`                                                                                                                                                         |                                                  |
+| registry.securityContext.runAsUser                | int    | `100`                                                                                                                                                          |                                                  |
+| registry.service.port                             | int    | `8080`                                                                                                                                                         |                                                  |
+| registry.service.type                             | string | `"ClusterIP"`                                                                                                                                                  |                                                  |
+| registry.tenantId                                 | string | `"default-tenant"`                                                                                                                                             |                                                  |
+| registry.useGranularAccessControl                 | string | `"false"`                                                                                                                                                      |                                                  |
 
 ----------------------------------------------
-Autogenerated from chart metadata using [helm-docs v1.11.0](https://github.com/norwoodj/helm-docs/releases/v1.11.0)
+Autogenerated from chart metadata using [helm-docs v1.11.3](https://github.com/norwoodj/helm-docs/releases/v1.11.3)
+
+## NOTICE
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2021 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/sldt-digital-twin-registry

--- a/charts/registry/README.md.gotmpl
+++ b/charts/registry/README.md.gotmpl
@@ -38,7 +38,7 @@ To use the helm chart as a dependency:
 
 ```yaml
 dependencies:
-  - name: puris
+  - name: registry
     repository: https://eclipse-tractusx.github.io/charts/dev
     version: YOUR_VERSION
 ```

--- a/charts/registry/README.md.gotmpl
+++ b/charts/registry/README.md.gotmpl
@@ -1,0 +1,65 @@
+{{ template "chart.header" . }}
+
+{{ template "chart.deprecationWarning" . }}
+
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.description" . }}
+
+{{ template "chart.homepageLine" . }}
+
+{{ template "chart.maintainersSection" . }}
+
+{{ template "chart.sourcesSection" . }}
+
+{{ template "chart.requirementsSection" . }}
+
+## Prerequisites
+
+- Kubernetes 1.19+
+- Helm 3.2.0+
+- PV provisioner support in the underlying infrastructure
+
+## Install
+
+To install the chart with the release name `registry`:
+
+```shell
+$ helm repo add tractusx-dev https://eclipse-tractusx.github.io/charts/dev
+$ helm install registry tractusx-dev/registry
+```
+To install the helm chart into your cluster with your values:
+
+```shell
+$ helm install -f your-values.yaml registry tractusx-dev/registry
+```
+
+To use the helm chart as a dependency:
+
+```yaml
+dependencies:
+  - name: puris
+    repository: https://eclipse-tractusx.github.io/charts/dev
+    version: YOUR_VERSION
+```
+
+To install the local version in the namespace _semantics_:
+
+```shell
+
+helm dependency update .
+
+helm install registry -n semantics . --create-namespace
+```
+
+{{ template "chart.valuesSection" . }}
+
+{{ template "helm-docs.versionFooter" . }}
+
+## NOTICE
+
+This work is licensed under the [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0).
+
+- SPDX-License-Identifier: Apache-2.0
+- SPDX-FileCopyrightText: 2021 Contributors to the Eclipse Foundation
+- Source URL: https://github.com/eclipse-tractusx/sldt-digital-twin-registry

--- a/charts/registry/templates/registry/registry-ingress.yaml
+++ b/charts/registry/templates/registry/registry-ingress.yaml
@@ -35,6 +35,8 @@ spec:
     - hosts:
         - {{ .Values.registry.host }}
       secretName: {{ .Values.registry.ingress.tls.secretName | default "registry-certificate-secret" }}
+  {{- else }}
+    []  # Ensures tls is an empty list when not enabled
   {{- end }}
   {{- if .Values.registry.ingress.urlPrefix }}
   rules:

--- a/charts/registry/templates/registry/registry-ingress.yaml
+++ b/charts/registry/templates/registry/registry-ingress.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.registry.ingress.enabled }}
 ################################################################################
 # Copyright (c) 2021 Robert Bosch Manufacturing Solutions GmbH and others
+# Copyright (c) 2025 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V. (represented by Fraunhofer ISST)
 # Copyright (c) 2021 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
@@ -29,12 +30,13 @@ metadata:
     {{- include "dtr.labels" . | nindent 4 }}
 spec:
   ingressClassName: {{ .Values.registry.ingress.className }}
-  {{- if .Values.registry.ingress.tls }}
+  {{- if .Values.registry.ingress.tls.enabled }}
   tls:
     - hosts:
         - {{ .Values.registry.host }}
-      secretName: registry-certificate-secret
+      secretName: {{ .Values.registry.ingress.tls.secretName | default "registry-certificate-secret" }}
   {{- end }}
+  {{- if .Values.registry.ingress.urlPrefix }}
   rules:
     - host: {{ .Values.registry.host }}
       http:
@@ -46,4 +48,21 @@ spec:
                 name: {{ include "dtr.fullname" . }}
                 port:
                   number: {{ .Values.registry.service.port }}
+  {{- else }}
+  rules:
+    {{- range .Values.registry.ingress.rules }}
+    - host: {{ .host | default $.Values.registry.host }}
+      http:
+        paths:
+          {{- range .http.paths }}
+          - path: {{ .path }}
+            pathType: {{ .pathType | default "ImplementationSpecific" }}
+            backend:
+              service:
+                name: {{ include "dtr.fullname" $ }}
+                port:
+                  number: {{ $.Values.registry.service.port }}
+          {{- end }}
+    {{- end}}
+  {{- end}}
 {{- end}}

--- a/charts/registry/values.yaml
+++ b/charts/registry/values.yaml
@@ -84,13 +84,13 @@ registry:
       secretName: registry-certificate-secret
     ## use a urlPrefix to define a path of pathType "Prefix" with regex. Result is a path "/semantics/registry(/|$)(.*)"
     urlPrefix: /semantics/registry
-    ## specify rules on your own, if the pathType Prefix + Regex runs into issues with your ClusterIssuer has a "strict-validate-path-type" check. -host.http.paths[0].path must at least be set. Then pathType "ImplementationSpecfic" is used with common service name and port. Multiple paths may be specified
-    rules: []
-#    #Minimum sample
+    ## specify rules on your own, if the pathType Prefix + Regex runs into issues with your ClusterIssuer has a "strict-validate-path-type" check. -host.http.paths[0].path must at least be set. Then pathType "ImplementationSpecific" is used with common service name and port. Multiple paths may be specified
+    rules: [ ]
+    #Minimum sample
 #      - host:
 #        http:
 #          paths:
-#            - path: /semantics/registry
+#            - path: /
 #              pathType:
 #              backend:
 #                service:

--- a/charts/registry/values.yaml
+++ b/charts/registry/values.yaml
@@ -1,5 +1,6 @@
 ################################################################################
 # Copyright (c) 2021 Robert Bosch Manufacturing Solutions GmbH and others
+# Copyright (c) 2025 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V. (represented by Fraunhofer ISST)
 # Copyright (c) 2021 Contributors to the Eclipse Foundation
 #
 # See the NOTICE file(s) distributed with this work for additional
@@ -75,9 +76,28 @@ registry:
     user: default-user
     password:
   ingress:
-    enabled: false
-    tls: false
+    enabled: true
+    tls:
+      ## enable tls, default false
+      enabled: true
+      ## reuse secret in namespace with given name, default "registry-certificate-secret"
+      secretName: registry-certificate-secret
+    ## use a urlPrefix to define a path of pathType "Prefix" with regex. Result is a path "/semantics/registry(/|$)(.*)"
     urlPrefix: /semantics/registry
+    ## specify rules on your own, if the pathType Prefix + Regex runs into issues with your ClusterIssuer has a "strict-validate-path-type" check. -host.http.paths[0].path must at least be set. Then pathType "ImplementationSpecfic" is used with common service name and port. Multiple paths may be specified
+    rules: []
+#    #Minimum sample
+#      - host:
+#        http:
+#          paths:
+#            - path: /semantics/registry
+#              pathType:
+#              backend:
+#                service:
+#                  name:
+#                  port:
+#                    number:
+
     className: nginx
     annotations: {}
       # Add annotations for the ingress, e.g.:

--- a/charts/registry/values.yaml
+++ b/charts/registry/values.yaml
@@ -85,8 +85,8 @@ registry:
     ## use a urlPrefix to define a path of pathType "Prefix" with regex. Result is a path "/semantics/registry(/|$)(.*)"
     urlPrefix: /semantics/registry
     ## specify rules on your own, if the pathType Prefix + Regex runs into issues with your ClusterIssuer has a "strict-validate-path-type" check. -host.http.paths[0].path must at least be set. Then pathType "ImplementationSpecific" is used with common service name and port. Multiple paths may be specified
-    rules: [ ]
-    #Minimum sample
+    rules: []
+    # Minimum sample
 #      - host:
 #        http:
 #          paths:


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

Currently the ingress configuration has been constrained, leading to issues:

- prefix conflicts with strict admission hooks (nginx doesn't allow prefix + wildcard, now also on INT)
- tls-secret may not be overwritten manually

I provided changes:

- tls secret now can be passed through (allows two dtr in the same namespace)
- ingress can now also be used as ` implementationSpecific` for path `/`
- provided a go template for helm-docs
- updated changelog (we can discuss if patch or minor change)

### Sample

#### Output with defaults

` helm template . > dtr.yaml` 

checking the ingress resource

```ingress.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: release-name-digital-twin-registry
  annotations:
    {}
  labels:
    helm.sh/chart: digital-twin-registry-0.7.1
    app.kubernetes.io/name: digital-twin-registry
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "0.7.1"
    app.kubernetes.io/managed-by: Helm
spec:
  ingressClassName: nginx
  tls:
    - hosts:
        - minikube
      secretName: registry-certificate-secret
  rules:
    - host: minikube
      http:
        paths:
          - path: /semantics/registry(/|$)(.*)
            pathType: Prefix
            backend:
              service:
                name: release-name-digital-twin-registry
                port:
                  number: 8080
```

Sample `ingress-values.yaml` for implementation specific:

```yaml
registry:
  ingress:
    enabled: true
    urlPrefix: ""
    tls:
      enabled: true
      secret: test
    rules:
      - host:
        http:
          paths:
            - path: /
    className: nginx
    annotations: {
      cert-manager.io/cluster-issuer: "letsencrypt",
      nginx.ingress.kubernetes.io/force-ssl-redirect: "true",
      nginx.ingress.kubernetes.io/ssl-passthrough: "true",
```

` helm template . -f ingress.yaml > dtr-ingress.yaml` 

Leads to filtered ingress

```yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: release-name-digital-twin-registry
  annotations:
    cert-manager.io/cluster-issuer: letsencrypt
    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
    nginx.ingress.kubernetes.io/ssl-passthrough: "true"
  labels:
    helm.sh/chart: digital-twin-registry-0.7.0
    app.kubernetes.io/name: digital-twin-registry
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "0.7.0"
    app.kubernetes.io/managed-by: Helm
spec:
  ingressClassName: nginx
  tls:
    - hosts:
        - TODO
      secretName: registry-certificate-secret
  rules:
    - host: TODO
      http:
        paths:
          - path: /
            pathType: ImplementationSpecific
            backend:
              service:
                name: release-name-digital-twin-registry
                port:
                  number: 8080
```

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
