### PR TITLE
fix: high number of select statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## 0.8.2
-### Added
-### Fixed
-- Bugfix: High number of SELECT statements during pagination
-
 ## 0.8.1 
 ### Added
 ### Changed
 ### Fixed
  - Restore IDTA conformity and reinstate max length of subprotocolBody to 2048
+ - High number of SELECT statements during pagination
 
 ## 0.8.0
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 ## fixed
 - Bugfix: removed uniqueness check for idShort validation while shell creation
+- Bugfix: High number of SELECT statements during pagination
 
 ## 0.7.0
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 ## fixed
 - Bugfix: removed uniqueness check for idShort validation while shell creation
+- Bugfix: passthrough ingress tls secret
 - Bugfix: High number of SELECT statements during pagination
 
 ## 0.7.0

--- a/access-control-service-interface/src/main/java/org/eclipse/tractusx/semantics/accesscontrol/api/AccessControlRuleService.java
+++ b/access-control-service-interface/src/main/java/org/eclipse/tractusx/semantics/accesscontrol/api/AccessControlRuleService.java
@@ -20,6 +20,7 @@
 
 package org.eclipse.tractusx.semantics.accesscontrol.api;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -37,5 +38,7 @@ public interface AccessControlRuleService {
    ShellVisibilityCriteria fetchVisibilityCriteriaForShell( ShellVisibilityContext shellContext, String bpn ) throws DenyAccessException;
 
    Map<String, ShellVisibilityCriteria> fetchVisibilityCriteriaForShells( List<ShellVisibilityContext> shellContexts, String bpn );
+
+   Map<String,Set<String>> findAllByBpnWithinValidityPeriod( String bpn, Instant now );
 
 }

--- a/access-control-service-interface/src/main/java/org/eclipse/tractusx/semantics/accesscontrol/api/AccessControlRuleService.java
+++ b/access-control-service-interface/src/main/java/org/eclipse/tractusx/semantics/accesscontrol/api/AccessControlRuleService.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2024 Robert Bosch Manufacturing Solutions GmbH and others
- * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2025 Robert Bosch Manufacturing Solutions GmbH and others
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/access-control-service-sql-impl/src/main/java/org/eclipse/tractusx/semantics/accesscontrol/sql/service/SqlBackedAccessControlRuleService.java
+++ b/access-control-service-sql-impl/src/main/java/org/eclipse/tractusx/semantics/accesscontrol/sql/service/SqlBackedAccessControlRuleService.java
@@ -171,4 +171,23 @@ public class SqlBackedAccessControlRuleService implements AccessControlRuleServi
       return accessRulePolicy.getMandatorySpecificAssetIds().stream()
             .filter( mandatory -> accessRulePolicy.getVisibleSpecificAssetIdNames().contains( mandatory.name() ) );
    }
+
+   /**
+    * Retrieves all mandatory specific asset ID name-value pairs for a given BPN (Business Partner Number)
+    * within the validity period.
+    *
+    * This method queries the repository to find all access rules associated with the specified BPN
+    * and maps their mandatory specific asset IDs into a grouped structure of names and corresponding values.
+    *
+    * @param bpn The Business Partner Number for which the mandatory specific asset IDs are to be retrieved.
+    * @param instant The timestamp representing the current time to filter access rules within their validity period.
+    * @return A map where the keys are specific asset ID names and the values are sets of corresponding specific asset ID values.
+    */
+   public Map<String,Set<String>> findAllByBpnWithinValidityPeriod( String bpn, Instant instant ){
+         return repository.findAllByBpnWithinValidityPeriod( bpn, bpnWildcard, instant ).stream()
+         .map(AccessRule::getPolicy )
+         .map(AccessRulePolicy::getMandatorySpecificAssetIds)
+         .flatMap(Collection::stream)
+         .collect( Collectors.groupingBy(SpecificAssetId::name, Collectors.mapping(SpecificAssetId::value, Collectors.toSet())));
+   }
 }

--- a/access-control-service-sql-impl/src/main/java/org/eclipse/tractusx/semantics/accesscontrol/sql/service/SqlBackedAccessControlRuleService.java
+++ b/access-control-service-sql-impl/src/main/java/org/eclipse/tractusx/semantics/accesscontrol/sql/service/SqlBackedAccessControlRuleService.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2024 Robert Bosch Manufacturing Solutions GmbH and others
- * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2025 Robert Bosch Manufacturing Solutions GmbH and others
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/backend/src/main/java/org/eclipse/tractusx/semantics/registry/repository/ShellRepository.java
+++ b/backend/src/main/java/org/eclipse/tractusx/semantics/registry/repository/ShellRepository.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2021 Robert Bosch Manufacturing Solutions GmbH and others
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2025 Robert Bosch Manufacturing Solutions GmbH and others
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/backend/src/main/java/org/eclipse/tractusx/semantics/registry/repository/ShellRepository.java
+++ b/backend/src/main/java/org/eclipse/tractusx/semantics/registry/repository/ShellRepository.java
@@ -28,6 +28,10 @@ import java.util.UUID;
 
 import org.eclipse.tractusx.semantics.registry.model.Shell;
 import org.eclipse.tractusx.semantics.registry.model.projection.ShellMinimal;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
@@ -146,4 +150,7 @@ public interface ShellRepository extends JpaRepository<Shell, UUID>, JpaSpecific
 
    @Query("SELECT s.createdDate FROM Shell s WHERE s.idExternal = :idExternal")
    Optional<Instant> getCreatedDateByIdExternal( String idExternal );
+
+   @EntityGraph(attributePaths = {"id"})
+   Page<Shell> findAll(Specification<Shell> spec, Pageable pageable);
 }

--- a/backend/src/main/java/org/eclipse/tractusx/semantics/registry/service/GranularShellAccessHandler.java
+++ b/backend/src/main/java/org/eclipse/tractusx/semantics/registry/service/GranularShellAccessHandler.java
@@ -66,7 +66,6 @@ public class GranularShellAccessHandler implements ShellAccessHandler {
    public Specification<Shell> shellFilterSpecification( String sortFieldName, ShellCursor cursor, String externalSubjectId ) {
       return ( root, query, criteriaBuilder ) -> {
          Instant searchValue = cursor.getShellSearchCursor();
-         query.orderBy( criteriaBuilder.asc( criteriaBuilder.coalesce( root.get( sortFieldName ), Instant.now() ) ) );
          return criteriaBuilder.greaterThan( root.get( sortFieldName ), searchValue );
       };
    }

--- a/backend/src/main/java/org/eclipse/tractusx/semantics/registry/service/GranularShellAccessHandler.java
+++ b/backend/src/main/java/org/eclipse/tractusx/semantics/registry/service/GranularShellAccessHandler.java
@@ -35,7 +35,6 @@ import org.eclipse.tractusx.semantics.accesscontrol.api.exception.DenyAccessExce
 import org.eclipse.tractusx.semantics.accesscontrol.api.model.ShellVisibilityContext;
 import org.eclipse.tractusx.semantics.accesscontrol.api.model.ShellVisibilityCriteria;
 import org.eclipse.tractusx.semantics.accesscontrol.api.model.SpecificAssetId;
-import org.eclipse.tractusx.semantics.registry.model.ReferenceKeyType;
 import org.eclipse.tractusx.semantics.registry.model.Shell;
 import org.eclipse.tractusx.semantics.registry.model.ShellIdentifier;
 import org.eclipse.tractusx.semantics.registry.model.Submodel;

--- a/backend/src/main/java/org/eclipse/tractusx/semantics/registry/service/GranularShellAccessHandler.java
+++ b/backend/src/main/java/org/eclipse/tractusx/semantics/registry/service/GranularShellAccessHandler.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2024 Robert Bosch Manufacturing Solutions GmbH and others
- * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ * Copyright (c) 2025 Robert Bosch Manufacturing Solutions GmbH and others
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/backend/src/main/java/org/eclipse/tractusx/semantics/registry/service/ShellService.java
+++ b/backend/src/main/java/org/eclipse/tractusx/semantics/registry/service/ShellService.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2021 Robert Bosch Manufacturing Solutions GmbH and others
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2025 Robert Bosch Manufacturing Solutions GmbH and others
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/backend/src/main/java/org/eclipse/tractusx/semantics/registry/service/ShellService.java
+++ b/backend/src/main/java/org/eclipse/tractusx/semantics/registry/service/ShellService.java
@@ -37,10 +37,12 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.eclipse.tractusx.semantics.RegistryProperties;
 import org.eclipse.tractusx.semantics.aas.registry.model.InlineResponse200;
 import org.eclipse.tractusx.semantics.aas.registry.model.PagedResultPagingMetadata;
 import org.eclipse.tractusx.semantics.aas.registry.model.SearchAllShellsByAssetLink200Response;
+import org.eclipse.tractusx.semantics.accesscontrol.api.AccessControlRuleService;
 import org.eclipse.tractusx.semantics.accesscontrol.api.exception.DenyAccessException;
 import org.eclipse.tractusx.semantics.accesscontrol.api.model.SpecificAssetId;
 import org.eclipse.tractusx.semantics.registry.dto.BatchResultDto;
@@ -68,6 +70,7 @@ import com.google.common.collect.ImmutableSet;
 
 import jakarta.persistence.criteria.Fetch;
 import jakarta.persistence.criteria.JoinType;
+import jakarta.persistence.criteria.Predicate;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -92,12 +95,15 @@ public class ShellService {
    private final String externalSubjectIdWildcardPrefix;
    private final List<String> externalSubjectIdWildcardAllowedTypes;
    private final int granularAccessControlFetchSize;
+   private final boolean isGranularAccessControlEnabled;
+   private final AccessControlRuleService accessControlRuleService;
 
    public ShellService( ShellRepository shellRepository,
          ShellIdentifierRepository shellIdentifierRepository,
          SubmodelRepository submodelRepository,
          RegistryProperties registryProperties,
-         ShellAccessHandler shellAccessHandler ) {
+         ShellAccessHandler shellAccessHandler,
+         AccessControlRuleService accessControlRuleService) {
       this.shellRepository = shellRepository;
       this.shellIdentifierRepository = shellIdentifierRepository;
       this.submodelRepository = submodelRepository;
@@ -106,6 +112,8 @@ public class ShellService {
       this.externalSubjectIdWildcardPrefix = registryProperties.getExternalSubjectIdWildcardPrefix();
       this.externalSubjectIdWildcardAllowedTypes = registryProperties.getExternalSubjectIdWildcardAllowedTypes();
       this.granularAccessControlFetchSize = Optional.ofNullable( registryProperties.getGranularAccessControlFetchSize() ).orElse( DEFAULT_FETCH_SIZE );
+      this.isGranularAccessControlEnabled = registryProperties.getUseGranularAccessControl();
+      this.accessControlRuleService = accessControlRuleService;
    }
 
    @Transactional
@@ -184,7 +192,7 @@ public class ShellService {
    public static Specification<Shell> withAllAssociations() {
        return (root, query, criteriaBuilder) -> {
            // Only apply fetching for entity queries, not for count queries
-           if (query.getResultType() != Long.class && query.getResultType() != long.class) {
+           if (query != null && query.getResultType() != Long.class && query.getResultType() != long.class) {
                // Set distinct to true to avoid duplicates
                query.distinct(true);
 
@@ -219,12 +227,25 @@ public class ShellService {
 
       pageSize = getPageSize( pageSize );
       ShellCursor cursor = new ShellCursor( pageSize, cursorVal );
-      var specification = shellAccessHandler.shellFilterSpecification(SORT_FIELD_NAME_SHELL, cursor, externalSubjectId)
-          .and(withAllAssociations());
+      var specification = shellAccessHandler.shellFilterSpecification(SORT_FIELD_NAME_SHELL, cursor, externalSubjectId);
       final var foundList = new ArrayList<Shell>();
       //fetch 1 more item to make sure there is a visible item for the next page
       while ( foundList.size() < pageSize + 1 ) {
-         Page<Shell> currentPage = shellRepository.findAll( specification, ofSize( granularAccessControlFetchSize ) );
+         specification = setMandatorySpecificIdsAndValues( externalSubjectId, specification );
+
+         var shellList = shellRepository.findAll(specification, ofSize( granularAccessControlFetchSize ));
+         var shellIdList = shellList.stream().map( Shell::getId ).toList();
+
+         if ( CollectionUtils.isEmpty( shellIdList)) {
+              break;
+         }
+         // Add shellIds filter to the existing specification
+         // This code snippet modifies an existing JPA Specification by adding a filter condition.
+         // The filter ensures that only entities with an "id" attribute matching one of the IDs in the `shellIdList` are included in the query results.
+         specification = specification.and((root, query, criteriaBuilder) ->
+             root.get("id").in(shellIdList));
+
+         Page<Shell> currentPage = shellRepository.findAll( specification.and(withAllAssociations()), ofSize( granularAccessControlFetchSize ) );
          List<Shell> shells = shellAccessHandler.filterListOfShellProperties( currentPage.stream().toList(), externalSubjectId );
          shells.stream()
                .limit( (long) pageSize + 1 - foundList.size() )
@@ -248,6 +269,58 @@ public class ShellService {
             .items( resultList )
             .cursor( nextCursor )
             .build();
+   }
+
+   /**
+    * Adds mandatory specific asset ID filters to the given JPA Specification.
+    *
+    * This method modifies the provided Specification to include filtering conditions
+    * based on specific asset IDs and their values. It ensures that only entities
+    * matching the specified criteria are included in the query results.
+    *
+    * The filtering is applied only if granular access control is enabled and the
+    * `externalSubjectId` does not match the owning tenant ID.
+    *
+    * @param externalSubjectId The external subject ID of the user making the request.
+    * @param specification The existing JPA Specification to be modified.
+    * @return Specification<Shell> The modified Specification with additional filtering conditions.
+    */
+   private Specification<Shell> setMandatorySpecificIdsAndValues(String externalSubjectId, Specification<Shell> specification) {
+    if(isGranularAccessControlEnabled && !owningTenantId.equals( externalSubjectId )) {
+       var specificAssetIdNameAndNameSet =  accessControlRuleService.findAllByBpnWithinValidityPeriod(externalSubjectId,Instant.now());
+
+            // Add filtering by specific asset IDs to the specification
+           specification = specification.and((root, query, criteriaBuilder) -> {
+               // Skip if there are no identifiers to filter by
+               if (specificAssetIdNameAndNameSet == null || specificAssetIdNameAndNameSet.isEmpty()) {
+                   return criteriaBuilder.conjunction(); // always true
+               }
+
+               // Ensure distinct results to avoid duplicates
+               Optional.ofNullable( query ).ifPresent( queryDetails -> queryDetails.distinct(true));
+
+               // Join Shell with ShellIdentifier entities
+               var identifierJoin = root.join("identifiers", JoinType.LEFT);
+
+               // Create predicates for each key-value pair
+               var predicates =  specificAssetIdNameAndNameSet.entrySet().stream().filter( stringSetEntry -> CollectionUtils.isNotEmpty( stringSetEntry.getValue() ))
+               .map( stringSetEntry -> {
+                  Predicate keyPredicate = criteriaBuilder.equal(identifierJoin.get("key"), stringSetEntry.getKey());
+                  Predicate valuePredicate = identifierJoin.get("value").in(stringSetEntry.getValue());
+                  return criteriaBuilder.and(keyPredicate, valuePredicate);
+               }).toList();
+
+               // If no valid predicates were created, return always true
+               if (CollectionUtils.isEmpty( predicates )) {
+                   return criteriaBuilder.conjunction();
+               }
+
+               // Return OR of all key-value pair predicates (shell matches if it has ANY of the pairs)
+               return criteriaBuilder.or(predicates.toArray(new Predicate[0]));
+           });
+
+      }
+    return specification;
    }
 
    @Transactional( readOnly = true )

--- a/backend/src/main/java/org/eclipse/tractusx/semantics/registry/utils/ShellSpecification.java
+++ b/backend/src/main/java/org/eclipse/tractusx/semantics/registry/utils/ShellSpecification.java
@@ -1,6 +1,6 @@
 /*******************************************************************************
- * Copyright (c) 2021 Robert Bosch Manufacturing Solutions GmbH and others
- * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ * Copyright (c) 2025 Robert Bosch Manufacturing Solutions GmbH and others
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.

--- a/backend/src/main/java/org/eclipse/tractusx/semantics/registry/utils/ShellSpecification.java
+++ b/backend/src/main/java/org/eclipse/tractusx/semantics/registry/utils/ShellSpecification.java
@@ -55,7 +55,6 @@ public class ShellSpecification<T> implements Specification<T> {
    private Predicate applyFilter( Root<T> root, CriteriaQuery<?> cq, CriteriaBuilder criteriaBuilder ) {
       if ( root.toString().contains( "Shell" ) ) {
          Instant searchValue = shellCursor.getShellSearchCursor();
-         cq.orderBy( criteriaBuilder.asc( criteriaBuilder.coalesce( root.get( sortFieldName ), Instant.now() ) ) );
 
          if ( owningTenantId.equals( tenantId ) ) {
             return criteriaBuilder.greaterThan( root.get( sortFieldName ), searchValue );


### PR DESCRIPTION
This pull request introduces enhancements to pagination, access control, and query optimization within the registry service. Key changes include the addition of granular access control filtering, improvements to pagination queries, and the introduction of new methods for managing access rules and associations.

### Enhancements to Access Control:
* Added a new method `findAllByBpnWithinValidityPeriod` in `AccessControlRuleService` to retrieve mandatory specific asset IDs for a given BPN within a validity period. [[1]](diffhunk://#diff-46b02c107cec27f5b05e7aba736ff1edc372f4fa03f451d671a3c68c0f5c8a72R42-R43) [[2]](diffhunk://#diff-e61b2e56cca0882018162217866c8210588134d39d6ed678eb546eff5e4bb743R174-R192)
* Introduced granular access control in `ShellService`, including a feature to filter results based on mandatory specific asset IDs and their values. [[1]](diffhunk://#diff-47080ea6f0ada64e7e249a285de131bdc4cd01faa85b07f1007384210cd2d9ccL179-R248) [[2]](diffhunk://#diff-47080ea6f0ada64e7e249a285de131bdc4cd01faa85b07f1007384210cd2d9ccR274-R325)

### Pagination and Query Optimization:
* Enhanced the `findAllShells` method in `ShellService` to include filtering by associations and mandatory specific asset IDs, ensuring efficient pagination with distinct results. [[1]](diffhunk://#diff-47080ea6f0ada64e7e249a285de131bdc4cd01faa85b07f1007384210cd2d9ccL179-R248) [[2]](diffhunk://#diff-47080ea6f0ada64e7e249a285de131bdc4cd01faa85b07f1007384210cd2d9ccR274-R325)
* Added a new query method `findAll` in `ShellRepository` with support for `Specification` and `Pageable` for paginated results.

### Codebase Improvements:
* Added a static method `withAllAssociations` in `ShellService` to create a JPA specification for fetching all associations of the `Shell` entity, improving modularity and reusability.
* Removed redundant ordering logic in `ShellSpecification` and `GranularShellAccessHandler` to streamline query definitions. [[1]](diffhunk://#diff-5db4fed663fb0611c427f522ffeef06413485cd38e92483a4ec7be47b3add546L69) [[2]](diffhunk://#diff-1964e1c869932c320e1e62b07188773b763f4f0da2793b79383c2f8df4874eccL58)

### Documentation and Miscellaneous:
* Updated the `CHANGELOG.md` to include a note about reducing the number of SELECT statements during pagination.
* Minor import optimizations across several files for better maintainability. [[1]](diffhunk://#diff-46b02c107cec27f5b05e7aba736ff1edc372f4fa03f451d671a3c68c0f5c8a72R23) [[2]](diffhunk://#diff-47080ea6f0ada64e7e249a285de131bdc4cd01faa85b07f1007384210cd2d9ccR71-R73)


## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
