### PR TITLE
fix: #522 subprotocolbody limited to 128 characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.8.1 
+### Added
+### Changed
+### Fixed
+ - Restore IDTA conformity and reinstate max length of subprotocolBody to 2048
+
 ## 0.8.0
 ### Added
 Release version for 0.8.0

--- a/backend/src/main/resources/static/aas-registry-openapi.yaml
+++ b/backend/src/main/resources/static/aas-registry-openapi.yaml
@@ -1480,7 +1480,7 @@ components:
           maxLength: 128
           type: string
         subprotocolBody:
-          maxLength: 128
+          maxLength: 2048
           type: string
         subprotocolBodyEncoding:
           maxLength: 128

--- a/backend/src/test/resources/integrationtests/aas-registry-usecases/37_testCRUDShellWithLongSubProtocolBodyWithinSpecs/1_post_shell/expected-response.json
+++ b/backend/src/test/resources/integrationtests/aas-registry-usecases/37_testCRUDShellWithLongSubProtocolBodyWithinSpecs/1_post_shell/expected-response.json
@@ -1,0 +1,49 @@
+{
+  "status": 201,
+  "content": true,
+  "assertions": [],
+  "expectedPayload": {
+    "description":[],
+    "displayName":[],
+    "id":"237c2f3c-4b08-4057-957d-25f58c8737ce",
+    "specificAssetIds":[],
+    "submodelDescriptors":[
+      {
+        "id":"87a3e328-55bb-40c7-915e-a43aa788b1aa",
+        "endpoints":[
+          {
+            "interface":"interfaceNameExample",
+            "protocolInformation":{
+              "href":"http://endpoint-address",
+              "endpointProtocol":"endpointProtocolExample",
+              "endpointProtocolVersion":[
+                "1.1"
+              ],
+              "subprotocol":"",
+              "subprotocolBody":"id=9b0608e1-db04-45e4-9193-eac9b1faffbf;dspEndpoint=https://my-edc-for-catena-x-use-case.product-name.environment.edcaas-company.com/api/v1/dsp",
+              "subprotocolBodyEncoding":"subprotocolBodyExample",
+              "securityAttributes":[
+                {
+                  "type":"NONE",
+                  "key":"Security Attribute key",
+                  "value":"Security Attribute value"
+                }
+              ]
+            }
+          }
+        ],
+        "semanticId":{
+          "type":"ExternalReference",
+          "keys":[
+            {
+              "type":"Submodel",
+              "value":"semanticIdExample"
+            }
+          ]
+        },
+        "description":[],
+        "displayName":[]
+      }
+    ]
+  }
+}

--- a/backend/src/test/resources/integrationtests/aas-registry-usecases/37_testCRUDShellWithLongSubProtocolBodyWithinSpecs/1_post_shell/request.json
+++ b/backend/src/test/resources/integrationtests/aas-registry-usecases/37_testCRUDShellWithLongSubProtocolBodyWithinSpecs/1_post_shell/request.json
@@ -1,0 +1,51 @@
+{
+  "url": "/api/v3/shell-descriptors",
+  "tenant": "TENANT_ONE",
+  "method": "POST",
+  "body": {
+    "description":[],
+    "displayName":[],
+    "idShort":null,
+    "id":"237c2f3c-4b08-4057-957d-25f58c8737ce",
+    "specificAssetIds":[],
+    "submodelDescriptors":[
+      {
+        "idShort": null,
+        "id":"87a3e328-55bb-40c7-915e-a43aa788b1aa",
+        "endpoints":[
+          {
+            "interface":"interfaceNameExample",
+            "protocolInformation":{
+              "href":"http://endpoint-address",
+              "endpointProtocol":"endpointProtocolExample",
+              "endpointProtocolVersion":[
+                "1.1"
+              ],
+              "subprotocol":"",
+              "subprotocolBody":"id=9b0608e1-db04-45e4-9193-eac9b1faffbf;dspEndpoint=https://my-edc-for-catena-x-use-case.product-name.environment.edcaas-company.com/api/v1/dsp",
+              "subprotocolBodyEncoding":"subprotocolBodyExample",
+              "securityAttributes":[
+                {
+                  "type":"NONE",
+                  "key":"Security Attribute key",
+                  "value":"Security Attribute value"
+                }
+              ]
+            }
+          }
+        ],
+        "semanticId":{
+          "type":"ExternalReference",
+          "keys":[
+            {
+              "type":"Submodel",
+              "value":"semanticIdExample"
+            }
+          ]
+        },
+        "description":[],
+        "displayName":[]
+      }
+    ]
+  }
+}

--- a/backend/src/test/resources/integrationtests/aas-registry-usecases/37_testCRUDShellWithLongSubProtocolBodyWithinSpecs/2_get_shell_by_id/expected-response.json
+++ b/backend/src/test/resources/integrationtests/aas-registry-usecases/37_testCRUDShellWithLongSubProtocolBodyWithinSpecs/2_get_shell_by_id/expected-response.json
@@ -1,0 +1,49 @@
+{
+  "status": 200,
+  "content": true,
+  "assertions": [],
+  "expectedPayload": {
+    "description":[],
+    "displayName":[],
+    "id":"237c2f3c-4b08-4057-957d-25f58c8737ce",
+    "specificAssetIds":[],
+    "submodelDescriptors":[
+      {
+        "id":"87a3e328-55bb-40c7-915e-a43aa788b1aa",
+        "endpoints":[
+          {
+            "interface":"interfaceNameExample",
+            "protocolInformation":{
+              "href":"http://endpoint-address",
+              "endpointProtocol":"endpointProtocolExample",
+              "endpointProtocolVersion":[
+                "1.1"
+              ],
+              "subprotocol":"",
+              "subprotocolBody":"id=9b0608e1-db04-45e4-9193-eac9b1faffbf;dspEndpoint=https://my-edc-for-catena-x-use-case.product-name.environment.edcaas-company.com/api/v1/dsp",
+              "subprotocolBodyEncoding":"subprotocolBodyExample",
+              "securityAttributes":[
+                {
+                  "type":"NONE",
+                  "key":"Security Attribute key",
+                  "value":"Security Attribute value"
+                }
+              ]
+            }
+          }
+        ],
+        "semanticId":{
+          "type":"ExternalReference",
+          "keys":[
+            {
+              "type":"Submodel",
+              "value":"semanticIdExample"
+            }
+          ]
+        },
+        "description":[],
+        "displayName":[]
+      }
+    ]
+  }
+}

--- a/backend/src/test/resources/integrationtests/aas-registry-usecases/37_testCRUDShellWithLongSubProtocolBodyWithinSpecs/2_get_shell_by_id/request.json
+++ b/backend/src/test/resources/integrationtests/aas-registry-usecases/37_testCRUDShellWithLongSubProtocolBodyWithinSpecs/2_get_shell_by_id/request.json
@@ -1,0 +1,6 @@
+{
+  "url": "/api/v3/shell-descriptors/MjM3YzJmM2MtNGIwOC00MDU3LTk1N2QtMjVmNThjODczN2Nl",
+  "tenant": "TENANT_ONE",
+  "method": "GET",
+  "body": null
+}

--- a/backend/src/test/resources/integrationtests/aas-registry-usecases/37_testCRUDShellWithLongSubProtocolBodyWithinSpecs/3_update_shell/expected-response.json
+++ b/backend/src/test/resources/integrationtests/aas-registry-usecases/37_testCRUDShellWithLongSubProtocolBodyWithinSpecs/3_update_shell/expected-response.json
@@ -1,0 +1,6 @@
+{
+  "status": 204,
+  "content": false,
+  "assertions": [],
+  "expectedPayload": null
+}

--- a/backend/src/test/resources/integrationtests/aas-registry-usecases/37_testCRUDShellWithLongSubProtocolBodyWithinSpecs/3_update_shell/request.json
+++ b/backend/src/test/resources/integrationtests/aas-registry-usecases/37_testCRUDShellWithLongSubProtocolBodyWithinSpecs/3_update_shell/request.json
@@ -1,0 +1,51 @@
+{
+  "url": "/api/v3/shell-descriptors/MjM3YzJmM2MtNGIwOC00MDU3LTk1N2QtMjVmNThjODczN2Nl",
+  "tenant": "TENANT_ONE",
+  "method": "PUT",
+  "body": {
+    "description":[],
+    "displayName":[],
+    "idShort":null,
+    "id":"237c2f3c-4b08-4057-957d-25f58c8737ce",
+    "specificAssetIds":[],
+    "submodelDescriptors":[
+      {
+        "idShort": null,
+        "id":"87a3e328-55bb-40c7-915e-a43aa788b1aa",
+        "endpoints":[
+          {
+            "interface":"interfaceNameExample",
+            "protocolInformation":{
+              "href":"http://endpoint-address",
+              "endpointProtocol":"endpointProtocolExample",
+              "endpointProtocolVersion":[
+                "1.1"
+              ],
+              "subprotocol":"",
+              "subprotocolBody":"id=87a3e328-55bb-40c7-915e-a43aa788b1aa;dspEndpoint=https://my-edc-for-catena-x-use-case.product-name.environment.edcaas-company.com/api/v1/dsp",
+              "subprotocolBodyEncoding":"subprotocolBodyExample",
+              "securityAttributes":[
+                {
+                  "type":"NONE",
+                  "key":"Security Attribute key",
+                  "value":"Security Attribute value"
+                }
+              ]
+            }
+          }
+        ],
+        "semanticId":{
+          "type":"ExternalReference",
+          "keys":[
+            {
+              "type":"Submodel",
+              "value":"semanticIdExample"
+            }
+          ]
+        },
+        "description":[],
+        "displayName":[]
+      }
+    ]
+  }
+}

--- a/backend/src/test/resources/integrationtests/aas-registry-usecases/37_testCRUDShellWithLongSubProtocolBodyWithinSpecs/4_get_updated_shell/expected-response.json
+++ b/backend/src/test/resources/integrationtests/aas-registry-usecases/37_testCRUDShellWithLongSubProtocolBodyWithinSpecs/4_get_updated_shell/expected-response.json
@@ -1,0 +1,49 @@
+{
+  "status": 200,
+  "content": true,
+  "assertions": [],
+  "expectedPayload": {
+    "description":[],
+    "displayName":[],
+    "id":"237c2f3c-4b08-4057-957d-25f58c8737ce",
+    "specificAssetIds":[],
+    "submodelDescriptors":[
+      {
+        "id":"87a3e328-55bb-40c7-915e-a43aa788b1aa",
+        "endpoints":[
+          {
+            "interface":"interfaceNameExample",
+            "protocolInformation":{
+              "href":"http://endpoint-address",
+              "endpointProtocol":"endpointProtocolExample",
+              "endpointProtocolVersion":[
+                "1.1"
+              ],
+              "subprotocol":"",
+              "subprotocolBody":"id=87a3e328-55bb-40c7-915e-a43aa788b1aa;dspEndpoint=https://my-edc-for-catena-x-use-case.product-name.environment.edcaas-company.com/api/v1/dsp",
+              "subprotocolBodyEncoding":"subprotocolBodyExample",
+              "securityAttributes":[
+                {
+                  "type":"NONE",
+                  "key":"Security Attribute key",
+                  "value":"Security Attribute value"
+                }
+              ]
+            }
+          }
+        ],
+        "semanticId":{
+          "type":"ExternalReference",
+          "keys":[
+            {
+              "type":"Submodel",
+              "value":"semanticIdExample"
+            }
+          ]
+        },
+        "description":[],
+        "displayName":[]
+      }
+    ]
+  }
+}

--- a/backend/src/test/resources/integrationtests/aas-registry-usecases/37_testCRUDShellWithLongSubProtocolBodyWithinSpecs/4_get_updated_shell/request.json
+++ b/backend/src/test/resources/integrationtests/aas-registry-usecases/37_testCRUDShellWithLongSubProtocolBodyWithinSpecs/4_get_updated_shell/request.json
@@ -1,0 +1,6 @@
+{
+  "url": "/api/v3/shell-descriptors/MjM3YzJmM2MtNGIwOC00MDU3LTk1N2QtMjVmNThjODczN2Nl",
+  "tenant": "TENANT_ONE",
+  "method": "GET",
+  "body": null
+}

--- a/backend/src/test/resources/integrationtests/aas-registry-usecases/37_testCRUDShellWithLongSubProtocolBodyWithinSpecs/5_delete_shell/expected-response.json
+++ b/backend/src/test/resources/integrationtests/aas-registry-usecases/37_testCRUDShellWithLongSubProtocolBodyWithinSpecs/5_delete_shell/expected-response.json
@@ -1,0 +1,6 @@
+{
+  "status": 204,
+  "content": false,
+  "assertions": [],
+  "expectedPayload": null
+}

--- a/backend/src/test/resources/integrationtests/aas-registry-usecases/37_testCRUDShellWithLongSubProtocolBodyWithinSpecs/5_delete_shell/request.json
+++ b/backend/src/test/resources/integrationtests/aas-registry-usecases/37_testCRUDShellWithLongSubProtocolBodyWithinSpecs/5_delete_shell/request.json
@@ -1,0 +1,6 @@
+{
+  "url": "/api/v3/shell-descriptors/MjM3YzJmM2MtNGIwOC00MDU3LTk1N2QtMjVmNThjODczN2Nl",
+  "tenant": "TENANT_ONE",
+  "method": "DELETE",
+  "body": null
+}

--- a/backend/src/test/resources/integrationtests/aas-registry-usecases/37_testCRUDShellWithLongSubProtocolBodyWithinSpecs/6_get_deleted_shell/expected-response.json
+++ b/backend/src/test/resources/integrationtests/aas-registry-usecases/37_testCRUDShellWithLongSubProtocolBodyWithinSpecs/6_get_deleted_shell/expected-response.json
@@ -1,0 +1,6 @@
+{
+  "status": 404,
+  "content": false,
+  "assertions": [],
+  "expectedPayload": null
+}

--- a/backend/src/test/resources/integrationtests/aas-registry-usecases/37_testCRUDShellWithLongSubProtocolBodyWithinSpecs/6_get_deleted_shell/request.json
+++ b/backend/src/test/resources/integrationtests/aas-registry-usecases/37_testCRUDShellWithLongSubProtocolBodyWithinSpecs/6_get_deleted_shell/request.json
@@ -1,0 +1,6 @@
+{
+  "url": "/api/v3/shell-descriptors/MjM3YzJmM2MtNGIwOC00MDU3LTk1N2QtMjVmNThjODczN2Nl",
+  "tenant": "TENANT_ONE",
+  "method": "GET",
+  "body": null
+}

--- a/backend/src/test/resources/integrationtests/aas-registry-usecases/38_testCreateShellWithTooLongSubProtocolBodyOutsideSpecs/1_post_shell/expected-response.json
+++ b/backend/src/test/resources/integrationtests/aas-registry-usecases/38_testCreateShellWithTooLongSubProtocolBodyOutsideSpecs/1_post_shell/expected-response.json
@@ -1,0 +1,5 @@
+{
+  "status": 400,
+  "content": true,
+  "assertions": []
+}

--- a/backend/src/test/resources/integrationtests/aas-registry-usecases/38_testCreateShellWithTooLongSubProtocolBodyOutsideSpecs/1_post_shell/request.json
+++ b/backend/src/test/resources/integrationtests/aas-registry-usecases/38_testCreateShellWithTooLongSubProtocolBodyOutsideSpecs/1_post_shell/request.json
@@ -1,0 +1,51 @@
+{
+  "url": "/api/v3/shell-descriptors",
+  "tenant": "TENANT_ONE",
+  "method": "POST",
+  "body": {
+    "description":[],
+    "displayName":[],
+    "idShort":null,
+    "id":"237c2f3c-4b08-4057-957d-25f58c8737ce",
+    "specificAssetIds":[],
+    "submodelDescriptors":[
+      {
+        "idShort": null,
+        "id":"87a3e328-55bb-40c7-915e-a43aa788b1aa",
+        "endpoints":[
+          {
+            "interface":"interfaceNameExample",
+            "protocolInformation":{
+              "href":"http://endpoint-address",
+              "endpointProtocol":"endpointProtocolExample",
+              "endpointProtocolVersion":[
+                "1.1"
+              ],
+              "subprotocol":"",
+              "subprotocolBody":"id=9b0608e1-db04-45e4-9193-eac9b1faffbf-b8fbd162-4af9-4bb0-82a7-4aba8c4e66fd-42588fa3-5484-445a-944a-18504f7da4a1-a67c9aa5-81bb-4164-8eab-3298f64d3189-f97d226b-a3df-4836-b122-59fb3d241cf7-9b0608e1-db04-45e4-9193-eac9b1faffbf-b8fbd162-4af9-4bb0-82a7-4aba8c4e66fd-42588fa3-5484-445a-944a-18504f7da4a1-a67c9aa5-81bb-4164-8eab-3298f64d3189-f97d226b-a3df-4836-b122-59fb3d241cf79b0608e1-db04-45e4-9193-eac9b1faffbf-b8fbd162-4af9-4bb0-82a7-4aba8c4e66fd-42588fa3-5484-445a-944a-18504f7da4a1-a67c9aa5-81bb-4164-8eab-3298f64d3189-f97d226b-a3df-4836-b122-59fb3d241cf79b0608e1-db04-45e4-9193-eac9b1faffbf-b8fbd162-4af9-4bb0-82a7-4aba8c4e66fd-42588fa3-5484-445a-944a-18504f7da4a1-a67c9aa5-81bb-4164-8eab-3298f64d3189-f97d226b-a3df-4836-b122-59fb3d241cf7-9b0608e1-db04-45e4-9193-eac9b1faffbf-b8fbd162-4af9-4bb0-82a7-4aba8c4e66fd-42588fa3-5484-445a-944a-18504f7da4a1-a67c9aa5-81bb-4164-8eab-3298f64d3189-f97d226b-a3df-4836-b122-59fb3d241cf7-9b0608e1-db04-45e4-9193-eac9b1faffbf-b8fbd162-4af9-4bb0-82a7-4aba8c4e66fd-42588fa3-5484-445a-944a-18504f7da4a1-a67c9aa5-81bb-4164-8eab-3298f64d3189-f97d226b-a3df-4836-b122-59fb3d241cf79b0608e1-db04-45e4-9193-eac9b1faffbf-b8fbd162-4af9-4bb0-82a7-4aba8c4e66fd-42588fa3-5484-445a-944a-18504f7da4a1-a67c9aa5-81bb-4164-8eab-3298f64d3189-f97d226b-a3df-4836-b122-59fb3d241cf79b0608e1-db04-45e4-9193-eac9b1faffbf-b8fbd162-4af9-4bb0-82a7-4aba8c4e66fd-42588fa3-5484-445a-944a-18504f7da4a1-a67c9aa5-81bb-4164-8eab-3298f64d3189-f97d226b-a3df-4836-b122-59fb3d241cf7-9b0608e1-db04-45e4-9193-eac9b1faffbf-b8fbd162-4af9-4bb0-82a7-4aba8c4e66fd-42588fa3-5484-445a-944a-18504f7da4a1-a67c9aa5-81bb-4164-8eab-3298f64d3189-f97d226b-a3df-4836-b122-59fb3d241cf7-9b0608e1-db04-45e4-9193-eac9b1faffbf-b8fbd162-4af9-4bb0-82a7-4aba8c4e66fd-42588fa3-5484-445a-944a-18504f7da4a1-a67c9aa5-81bb-4164-8eab-3298f64d3189-f97d226b-a3df-4836-b122-59fb3d241cf79b0608e1-db04-45e4-9193-eac9b1faffbf-b8fbd162-4af9-4bb0-82a7-4aba8c4e66fd-42588fa3-5484-445a-944a-18504f7da4a1-a67c9aa5-81bb-4164-8eab-3298f64d3189-f97d226b-a3df-4836-b122-59fb3d241cf79b0608e1-db04-45e4-9193-eac9b1faffbf-b8fbd162-4af9-4bb0-82a7-4aba8c4e66fd-42588fa3-5484-445a-944a-18504f7da4a1-a67c9aa5-81bb-4164-8eab-3298f64d3189-f97d226b-a3df-4836-b122-59fb3d241cf7-9b0608e1-db04-45e4-9193-eac9b1faffbf-b8fbd162-4af9-4bb0-82a7-4aba8c4e66fd-42588fa3-5484-445a-944a-18504f7da4a1-a67c9aa5-81bb-4164-8eab-3298f64d3189-f97d226b-a3df-4836-b122-59fb3d241cf7-9b0608e1-db04-45e4-9193-eac9b1faffbf-b8fbd162-4af9-4bb0-82a7-4aba8c4e66fd-42588fa3-5484-445a-944a-18504f7da4a1-a67c9aa5-81bb-4164-8eab-3298f64d3189-f97d226b-a3df-4836-b122-59fb3d241cf79b0608e1-db04-45e4-9193-eac9b1faffbf-b8fbd162-4af9-4bb0-82a7-4aba8c4e66fd-42588fa3-5484-445a-944a-18504f7da4a1-a67c9aa5-81bb-4164-8eab-3298f64d3189-f97d226b-a3df-4836-b122-59fb3d241cf79b0608e1-db04-45e4-9193-eac9b1faffbf-b8fbd162-4af9-4bb0-82a7-4aba8c4e66fd-42588fa3-5484-445a-944a-18504f7da4a1-a67c9aa5-81bb-4164-8eab-3298f64d3189-f97d226b-a3df-4836-b122-59fb3d241cf7-9b0608e1-db04-45e4-9193-eac9b1faffbf-b8fbd162-4af9-4bb0-82a7-4aba8c4e66fd-42588fa3-5484-445a-944a-18504f7da4a1-a67c9aa5-81bb-4164-8eab-3298f64d3189-f97d226b-a3df-4836-b122-59fb3d241cf7-9b0608e1-db04-45e4-9193-eac9b1faffbf-b8fbd162-4af9-4bb0-82a7-4aba8c4e66fd-42588fa3-5484-445a-944a-18504f7da4a1-a67c9aa5-81bb-4164-8eab-3298f64d3189-f97d226b-a3df-4836-b122-59fb3d241cf79b0608e1-db04-45e4-9193-eac9b1faffbf-b8fbd162-4af9-4bb0-82a7-4aba8c4e66fd-42588fa3-5484-445a-944a-18504f7da4a1-a67c9aa5-81bb-4164-8eab-3298f64d3189-f97d226b-a3df-4836-b122-59fb3d241cf79b0608e1-db04-45e4-9193-eac9b1faffbf-b8fbd162-4af9-4bb0-82a7-4aba8c4e66fd-42588fa3-5484-445a-944a-18504f7da4a1-a67c9aa5-81bb-4164-8eab-3298f64d3189-f97d226b-a3df-4836-b122-59fb3d241cf7;dspEndpoint=https://my-edc-for-catena-x-use-case.product-name.environment.edcaas-company.com/api/v1/dsp",
+              "subprotocolBodyEncoding":"subprotocolBodyExample",
+              "securityAttributes":[
+                {
+                  "type":"NONE",
+                  "key":"Security Attribute key",
+                  "value":"Security Attribute value"
+                }
+              ]
+            }
+          }
+        ],
+        "semanticId":{
+          "type":"ExternalReference",
+          "keys":[
+            {
+              "type":"Submodel",
+              "value":"semanticIdExample"
+            }
+          ]
+        },
+        "description":[],
+        "displayName":[]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Increased subprotocolbody limit back to 2048, see issue #522

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs. - not applicable
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files - not applicable
