### PR TITLE
feat: Sonar PR trigger

### DIFF
--- a/.github/workflows/sonar-scan.yaml
+++ b/.github/workflows/sonar-scan.yaml
@@ -23,6 +23,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
   schedule:
     - cron: "0 0 * * *"
 


### PR DESCRIPTION
## Description
This pull request updates the `.github/workflows/sonar-scan.yaml` file to expand the conditions under which the SonarQube scan workflow is triggered.

Workflow trigger updates:

* [`.github/workflows/sonar-scan.yaml`](diffhunk://#diff-563053c325b683622c7051ffdd16dbc8657df0f5dd69d9a4101b2194d3ac7f65R26-R28): Added the `pull_request` event with the `main` branch as a condition to trigger the SonarQube scan workflow, in addition to the existing `push` and `schedule` events.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [- ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ -] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files