### PR TITLE
feat:migrate from oss.sonatype.orgto the new central.sonatype.org infrastructure

### DIFF
--- a/.github/workflows/publish-edc-ext-to-maven-central.yml
+++ b/.github/workflows/publish-edc-ext-to-maven-central.yml
@@ -59,7 +59,7 @@ jobs:
         run: |
           echo "use-agent" >> ~/.gnupg/gpg.conf
           echo "pinentry-mode loopback" >> ~/.gnupg/gpg.conf
-          echo -e "${{ secrets.ORG_GPG_PRIVATE_KEY }}" | gpg --import --batch
+          echo -e "${{ secrets.GPG_PRIVATE_KEY }}" | gpg --import --batch
           for fpr in $(gpg --list-keys --with-colons | awk -F: '/fpr:/ {print $10}' | sort -u);
           do
             echo -e "5\\ny\\n" |  gpg --batch --command-fd 0 --expert --edit-key $fpr trust;
@@ -67,8 +67,8 @@ jobs:
       - name: Publish to the Maven Central Repository
         shell: bash
         run: |
-          mvn clean verify nexus-staging:deploy -P release-to-central
+          mvn clean verify deploy
         env:
-          MAVEN_USERNAME: "${{ secrets.ORG_OSSRH_USERNAME }}"
-          MAVEN_PASSWORD: "${{ secrets.ORG_OSSRH_PASSWORD }}"
-          MAVEN_GPG_PASSPHRASE: "${{ secrets.ORG_GPG_PASSPHRASE }}"
+          MAVEN_USERNAME: "${{ secrets.CENTRAL_SONATYPE_TOKEN_USERNAME }}"
+          MAVEN_PASSWORD: "${{ secrets.CENTRAL_SONATYPE_TOKEN_PASSWORD }}"
+          MAVEN_GPG_PASSPHRASE: "${{ secrets.GPG_PASSPHRASE }}"

--- a/.github/workflows/sonar-scan.yaml
+++ b/.github/workflows/sonar-scan.yaml
@@ -23,6 +23,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
   schedule:
     - cron: "0 0 * * *"
 

--- a/.github/workflows/sonar-scan.yaml
+++ b/.github/workflows/sonar-scan.yaml
@@ -23,9 +23,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
   schedule:
     - cron: "0 0 * * *"
 

--- a/pom.xml
+++ b/pom.xml
@@ -357,6 +357,15 @@
 		<pluginManagement>
 			<plugins>
 				<plugin>
+					<groupId>org.sonatype.central</groupId>
+					<artifactId>central-publishing-maven-plugin</artifactId>
+					<version>0.8.0</version>
+					<extensions>true</extensions>
+					<configuration>
+						<publishingServerId>central</publishingServerId>
+					</configuration>
+				</plugin>
+				<plugin>
 					<groupId>org.eclipse.dash</groupId>
 					<artifactId>license-tool-plugin</artifactId>
 					<version>${license-tool-plugin-version}</version>
@@ -493,17 +502,6 @@
 					</executions>
 				</plugin>
 				<plugin>
-					<groupId>org.sonatype.plugins</groupId>
-					<artifactId>nexus-staging-maven-plugin</artifactId>
-					<version>1.6.13</version>
-					<extensions>true</extensions>
-					<configuration>
-						<serverId>ossrh</serverId>
-						<nexusUrl>https://oss.sonatype.org/</nexusUrl>
-						<autoReleaseAfterClose>true</autoReleaseAfterClose>
-					</configuration>
-				</plugin>
-				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-deploy-plugin</artifactId>
 					<version>2.8.2</version>
@@ -593,12 +591,12 @@
 
 	<distributionManagement>
 		<snapshotRepository>
-			<id>ossrh</id>
-			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
+			<id>central</id>
+			<url>https://central.sonatype.com/repository/maven-snapshots/</url>
 		</snapshotRepository>
 		<repository>
-			<id>ossrh</id>
-			<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+			<id>central</id>
+			<url>https://central.sonatype.com</url>
 		</repository>
 	</distributionManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -357,15 +357,6 @@
 		<pluginManagement>
 			<plugins>
 				<plugin>
-					<groupId>org.sonatype.central</groupId>
-					<artifactId>central-publishing-maven-plugin</artifactId>
-					<version>0.8.0</version>
-					<extensions>true</extensions>
-					<configuration>
-						<publishingServerId>central</publishingServerId>
-					</configuration>
-				</plugin>
-				<plugin>
 					<groupId>org.eclipse.dash</groupId>
 					<artifactId>license-tool-plugin</artifactId>
 					<version>${license-tool-plugin-version}</version>
@@ -500,6 +491,15 @@
 							</goals>
 						</execution>
 					</executions>
+				</plugin>
+				<plugin>
+					<groupId>org.sonatype.central</groupId>
+					<artifactId>central-publishing-maven-plugin</artifactId>
+					<version>0.8.0</version>
+					<extensions>true</extensions>
+					<configuration>
+						<publishingServerId>central</publishingServerId>
+					</configuration>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Description
This pull request updates the Maven publishing process to align with the new Sonatype Central infrastructure. The changes primarily involve updating secrets, Maven plugin configurations, and repository URLs to reflect the migration from OSSRH to Sonatype Central.

### Workflow updates:
* [`.github/workflows/publish-edc-ext-to-maven-central.yml`](diffhunk://#diff-807dcc734f45d8cbf5fbfa5199e638c9e64acd7c3b4556da950e209e837a58cdL62-R74): Updated secrets to use `GPG_PRIVATE_KEY`, `CENTRAL_SONATYPE_TOKEN_USERNAME`, and `CENTRAL_SONATYPE_TOKEN_PASSWORD`. Replaced the `nexus-staging:deploy` command with `deploy` for publishing.

### Maven plugin configuration updates:
* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L496-R501): Replaced the `nexus-staging-maven-plugin` with the `central-publishing-maven-plugin` (version 0.8.0). Updated the configuration to use `publishingServerId` instead of `serverId`.

### Repository URL updates:
* [`pom.xml`](diffhunk://#diff-9c5fb3d1b7e3b0f54bc5c4182965c4fe1f9023d449017cece3005d3f90e8e4d8L596-R599): Changed the `distributionManagement` repository and snapshot repository URLs to point to the new Sonatype Central endpoints (`https://central.sonatype.com`). Updated repository IDs from `ossrh` to `central`.
## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
