### PR TITLE
chore(Ingress): rework for compliance

### DIFF
--- a/charts/registry/templates/_helpers.tpl
+++ b/charts/registry/templates/_helpers.tpl
@@ -2,11 +2,12 @@
 Expand the name of the chart.
 */}}
 {{- define "dtr.name" -}}
-{{- default .Chart.Name .Values.nameOverride | replace "+" "_"  | trunc 63 | trimSuffix "-" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
 {{- end }}
 
 {{/*
 Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
 {{- define "dtr.fullname" -}}
@@ -41,10 +42,24 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
 
-
+{{/*
+Selector labels
+*/}}
 {{- define "dtr.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "dtr.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "dtr.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "dtr.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
 {{- end }}
 
 {{/*
@@ -62,3 +77,6 @@ Determine database hostname
 {{- end -}}
 {{- end -}}
 {{- end -}}
+
+
+

--- a/charts/registry/templates/registry/registry-ingress.yaml
+++ b/charts/registry/templates/registry/registry-ingress.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.registry.ingress.enabled }}
+{{- if .Values.registry.ingress.enabled -}}
 ################################################################################
 # Copyright (c) 2021 Robert Bosch Manufacturing Solutions GmbH and others
 # Copyright (c) 2025 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V. (represented by Fraunhofer ISST)
@@ -19,52 +19,69 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 ################################################################################
+{{- end }}
+{{ if .Values.registry.ingress.enabled -}}
+{{- $fullName := include "dtr.fullname" . -}}
+{{- $svcPort := .Values.registry.service.port -}}
+{{- /* handle old k8s versions for ingress.class annotation */ -}}
+{{- if and .Values.registry.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.registry.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.registry.ingress.annotations "kubernetes.io/ingress.class" .Values.registry.ingress.className }}
+  {{- end }}
+{{- end }}
 
+{{- /* choose API version */ -}}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
-  name: {{ include "dtr.fullname" . }}
-  annotations:
-{{ .Values.registry.ingress.annotations | toYaml | indent 4 }}
+  name: {{ $fullName }}-{{ .Values.registry.ingress.name }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "dtr.labels" . | nindent 4 }}
-spec:
-  ingressClassName: {{ .Values.registry.ingress.className }}
-  {{- if .Values.registry.ingress.tls.enabled }}
-  tls:
-    - hosts:
-        - {{ .Values.registry.host }}
-      secretName: {{ .Values.registry.ingress.tls.secretName | default "registry-certificate-secret" }}
-  {{- else }}
-    []  # Ensures tls is an empty list when not enabled
+  {{- with .Values.registry.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
   {{- end }}
-  {{- if .Values.registry.ingress.urlPrefix }}
+spec:
+  {{- if and .Values.registry.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.registry.ingress.className }}
+  {{- end }}
+  {{- if .Values.registry.ingress.tls }}
+  tls:
+    {{- range .Values.registry.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
   rules:
-    - host: {{ .Values.registry.host }}
+    {{- range .Values.registry.ingress.hosts }}
+    - host: {{ .host | quote }}
       http:
         paths:
-          - path: {{printf "%s(/|$)(.*)" .Values.registry.ingress.urlPrefix }}
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ include "dtr.fullname" . }}
-                port:
-                  number: {{ .Values.registry.service.port }}
-  {{- else }}
-  rules:
-    {{- range .Values.registry.ingress.rules }}
-    - host: {{ .host | default $.Values.registry.host }}
-      http:
-        paths:
-          {{- range .http.paths }}
+          {{- range .paths }}
           - path: {{ .path }}
-            pathType: {{ .pathType | default "ImplementationSpecific" }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
             backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
               service:
-                name: {{ include "dtr.fullname" $ }}
+                name: {{ $fullName }}
                 port:
-                  number: {{ $.Values.registry.service.port }}
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
           {{- end }}
-    {{- end}}
-  {{- end}}
-{{- end}}
+    {{- end }}
+{{- end }}

--- a/charts/registry/values.yaml
+++ b/charts/registry/values.yaml
@@ -37,7 +37,6 @@ registry:
   replicaCount: 1
   imagePullPolicy: IfNotPresent
   containerPort: 4243
-  host: minikube
   ## If 'authentication' is set to false, no OAuth authentication is enforced
   authentication: true
   # Issuer url for the dtr (resource server),
@@ -77,28 +76,7 @@ registry:
     password:
   ingress:
     enabled: true
-    tls:
-      ## enable tls, default false
-      enabled: true
-      ## reuse secret in namespace with given name, default "registry-certificate-secret"
-      secretName: registry-certificate-secret
-    ## use a urlPrefix to define a path of pathType "Prefix" with regex. Result is a path "/semantics/registry(/|$)(.*)"
-    urlPrefix: /semantics/registry
-    ## specify rules on your own, if the pathType Prefix + Regex runs into issues with your ClusterIssuer has a "strict-validate-path-type" check. -host.http.paths[0].path must at least be set. Then pathType "ImplementationSpecific" is used with common service name and port. Multiple paths may be specified
-    rules: []
-    # Minimum sample
-#      - host:
-#        http:
-#          paths:
-#            - path: /
-#              pathType:
-#              backend:
-#                service:
-#                  name:
-#                  port:
-#                    number:
-
-    className: nginx
+    name: "registry"
     annotations: {}
       # Add annotations for the ingress, e.g.:
       # cert-manager.io/cluster-issuer: selfsigned-cluster-issuer
@@ -107,6 +85,22 @@ registry:
       # nginx.ingress.kubernetes.io/enable-cors: "true"
       # nginx.ingress.kubernetes.io/cors-allow-credentials: "true"
       # nginx.ingress.kubernetes.io/x-forwarded-prefix: /semantics/registry
+    className: nginx
+    tls:
+      - hosts:
+        - "registry.example.com"
+        ## reuse secret in namespace with given name, default "registry-certificate-secret"
+        secretName: "registry-certificate-secret"
+    ## specify rules on your own, if the pathType Prefix + Regex runs into issues with your ClusterIssuer has a "strict-validate-path-type" check. -host.http.paths[0].path must at least be set. Then pathType "ImplementationSpecific" is used with common service name and port. Multiple paths may be specified
+    hosts: 
+      - host: "registry.example.com"
+        paths:
+          - path: /semantics/registry(/|$)(.*)
+            pathType: Prefix
+            backend:
+              service: dtr-fullname-placeholder
+              port: 8080
+
   resources:
     limits:
       cpu: 750m


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description

### What does this PR introduce? 

This change aligns the ingress controller definition to other tractus-x components . 
For this the following three files were adjusted:
* `charts/registry/templates/_helpers.tpl`
* `charts/registry/templates/registry/registry-ingress.yaml`
* `charts/registry/values.yaml`

As guideline, I used existing ingress templates from the tractus-x ecosystem. So, that they're following the same standards. 

### Does it fix a bug or add a new feature?

I would call it an enhancement of the existing solution. 

### Is it enhancing documentation?

Kind of. Keeping the ingress configuration similar across the tractus-x ecosystem, makes configuration easier.

### Changes
- Replaced existing ingress configuration logic based on existing tractus-x components ingress configuration. 
- Add version‑aware API version, `pathType` and TLS handling
- Updated `_helpers.tpl` based on current `helpers` generated by `helm`
- Validated with both `nginx` and `traefik` examples


### Related issues
Might be related to: 
https://github.com/eclipse-tractusx/sldt-digital-twin-registry/issues/519

### Discussion

Following, some remarks that might be a reason not to merge this PR and to receive feedback on. 

#### Not fully compliant with existing tractus-x components ingress configuration

I kept the **naming** of `ingress` rules and the `service` in accordance to the initial naming here. 
Mainly, since this would require to make more adjustments in other files and might increase the likelihood to break things. 
I could understand to rewrite this as well, to make it fully compliant but maybe this isn't needed. Any feedback would be appreciated.

#### Further testing

While the ingress rules generation seems to be correct, I couldn't manage to get `dtr` to work correctly yet. 
I think this shouldn't impact this PR since the issues seems to be something else. However, without a successful deployment i can't rule out that it might be related. 

### Tests
* initial
```yaml
---
# Source: digital-twin-registry/templates/registry/registry-ingress.yaml
################################################################################
# Copyright (c) 2021 Robert Bosch Manufacturing Solutions GmbH and others
# Copyright (c) 2025 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V. (represented by Fraunhofer ISST)
# Copyright (c) 2021 Contributors to the Eclipse Foundation
#
# See the NOTICE file(s) distributed with this work for additional
# information regarding copyright ownership.
#
# This program and the accompanying materials are made available under the
# terms of the Apache License, Version 2.0 which is available at
# https://www.apache.org/licenses/LICENSE-2.0.
#
# Unless required by applicable law or agreed to in writing, software
# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
# License for the specific language governing permissions and limitations
# under the License.
#
# SPDX-License-Identifier: Apache-2.0
################################################################################

apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: sldt-dtr-digital-twin-registry
  annotations:
    {}
  labels:
    helm.sh/chart: digital-twin-registry-0.8.1
    app.kubernetes.io/name: digital-twin-registry
    app.kubernetes.io/instance: sldt-dtr
    app.kubernetes.io/version: "0.8.1"
    app.kubernetes.io/managed-by: Helm
spec:
  ingressClassName: nginx
  tls:
    - hosts:
        - minikube
      secretName: registry-certificate-secret
  rules:
    - host: minikube
      http:
        paths:
          - path: /semantics/registry(/|$)(.*)
            pathType: Prefix
            backend:
              service:
                name: sldt-dtr-digital-twin-registry
                port:
                  number: 8080
```
* now
```yaml
---
# Source: digital-twin-registry/templates/registry/registry-ingress.yaml
################################################################################
# Copyright (c) 2021 Robert Bosch Manufacturing Solutions GmbH and others
# Copyright (c) 2025 Fraunhofer-Gesellschaft zur Foerderung der angewandten Forschung e.V. (represented by Fraunhofer ISST)
# Copyright (c) 2021 Contributors to the Eclipse Foundation
#
# See the NOTICE file(s) distributed with this work for additional
# information regarding copyright ownership.
#
# This program and the accompanying materials are made available under the
# terms of the Apache License, Version 2.0 which is available at
# https://www.apache.org/licenses/LICENSE-2.0.
#
# Unless required by applicable law or agreed to in writing, software
# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
# License for the specific language governing permissions and limitations
# under the License.
#
# SPDX-License-Identifier: Apache-2.0
################################################################################
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: sldt-dtr-digital-twin-registry-registry
  namespace: dtr
  labels:
    helm.sh/chart: digital-twin-registry-0.8.1
    app.kubernetes.io/name: digital-twin-registry
    app.kubernetes.io/instance: sldt-dtr
    app.kubernetes.io/version: "0.8.1"
    app.kubernetes.io/managed-by: Helm
spec:
  ingressClassName: nginx
  tls:
    - hosts:
        - "registry.example.com"
      secretName: registry-certificate-secret
  rules:
    - host: "registry.example.com"
      http:
        paths:
          - path: /semantics/registry(/|$)(.*)
            pathType: Prefix
            backend:
              service:
                name: sldt-dtr-digital-twin-registry
                port:
                  number: 8080
```

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
