### PR TITLE
feat: add matcher for shellsByAssetLink endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 ### Changed
 - Replace UUIDv4 with UUIDv7 to improve insert performance
-- Make `/lookup/shellsByAssetLink` endpoint accessible to `view_digital_twin` role
 ### Fixed
+- Make `/lookup/shellsByAssetLink` endpoint accessible to `view_digital_twin` role
 
 ## 0.9.0
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 ### Changed
 - Replace UUIDv4 with UUIDv7 to improve insert performance
+- Make `/lookup/shellsByAssetLink` endpoint accessible to `view_digital_twin` role
 ### Fixed
 
 ## 0.9.0

--- a/backend/src/main/java/org/eclipse/tractusx/semantics/registry/security/OAuthSecurityConfig.java
+++ b/backend/src/main/java/org/eclipse/tractusx/semantics/registry/security/OAuthSecurityConfig.java
@@ -61,6 +61,7 @@ public class OAuthSecurityConfig {
                     // lookup
                     // query endpoint is allowed for reader
                     .requestMatchers( HttpMethod.POST, "/**/lookup/**/query/**" ).access( "@authorizationEvaluator.hasRoleViewDigitalTwin()" )
+                    .requestMatchers( HttpMethod.POST, "/**/lookup/shellsByAssetLink" ).access( "@authorizationEvaluator.hasRoleViewDigitalTwin()" )
                     // others are HTTP method based
                     .requestMatchers( HttpMethod.GET, "/**/lookup/**" ).access( "@authorizationEvaluator.hasRoleViewDigitalTwin()" )
                     .requestMatchers( HttpMethod.POST, "/**/lookup/**" ).access( "@authorizationEvaluator.hasRoleAddDigitalTwin()" )

--- a/backend/src/main/java/org/eclipse/tractusx/semantics/registry/security/OAuthSecurityConfig.java
+++ b/backend/src/main/java/org/eclipse/tractusx/semantics/registry/security/OAuthSecurityConfig.java
@@ -61,7 +61,7 @@ public class OAuthSecurityConfig {
                     // lookup
                     // query endpoint is allowed for reader
                     .requestMatchers( HttpMethod.POST, "/**/lookup/**/query/**" ).access( "@authorizationEvaluator.hasRoleViewDigitalTwin()" )
-                    .requestMatchers( HttpMethod.POST, "/**/lookup/shellsByAssetLink" ).access( "@authorizationEvaluator.hasRoleViewDigitalTwin()" )
+                    .requestMatchers( HttpMethod.POST, "/**/lookup/shellsByAssetLink" ).access( "@authorizationEvaluator.hasRoleViewDigitalTwin() or @authorizationEvaluator.hasRoleAddDigitalTwin()" )
                     // others are HTTP method based
                     .requestMatchers( HttpMethod.GET, "/**/lookup/**" ).access( "@authorizationEvaluator.hasRoleViewDigitalTwin()" )
                     .requestMatchers( HttpMethod.POST, "/**/lookup/**" ).access( "@authorizationEvaluator.hasRoleAddDigitalTwin()" )

--- a/backend/src/test/java/org/eclipse/tractusx/semantics/registry/AssetAdministrationShellApiSecurityTest.java
+++ b/backend/src/test/java/org/eclipse/tractusx/semantics/registry/AssetAdministrationShellApiSecurityTest.java
@@ -525,6 +525,32 @@ public class AssetAdministrationShellApiSecurityTest extends AbstractAssetAdmini
                .andExpect( status().isOk() );
       }
 
+      @Test
+      public void testRbacForLookupShellsByAssetLink() throws Exception {
+         ArrayNode specificAssetIds = emptyArrayNode()
+               .add( specificAssetId( "key1", "value1" ) )
+               .add( specificAssetId( "key2", "value2" ) );
+
+         mvc.perform(
+                     MockMvcRequestBuilders
+                           .post( LOOKUP_SHELL_BASE_PATH_POST )
+                           .contentType( MediaType.APPLICATION_JSON )
+                           .content( toJson( specificAssetIds ) )
+                           .with( jwtTokenFactory.addTwin() )
+               )
+               .andDo( MockMvcResultHandlers.print() )
+               .andExpect( status().isForbidden() );
+         mvc.perform(
+                     MockMvcRequestBuilders
+                           .post( LOOKUP_SHELL_BASE_PATH_POST )
+                           .contentType( MediaType.APPLICATION_JSON )
+                           .accept( MediaType.APPLICATION_JSON )
+                           .content( toJson( specificAssetIds ) )
+                           .with( jwtTokenFactory.readTwin() )
+               )
+               .andDo( MockMvcResultHandlers.print() )
+               .andExpect( status().isOk() );
+      }
    }
 
    @Nested

--- a/backend/src/test/java/org/eclipse/tractusx/semantics/registry/AssetAdministrationShellApiSecurityTest.java
+++ b/backend/src/test/java/org/eclipse/tractusx/semantics/registry/AssetAdministrationShellApiSecurityTest.java
@@ -536,10 +536,20 @@ public class AssetAdministrationShellApiSecurityTest extends AbstractAssetAdmini
                            .post( LOOKUP_SHELL_BASE_PATH_POST )
                            .contentType( MediaType.APPLICATION_JSON )
                            .content( toJson( specificAssetIds ) )
-                           .with( jwtTokenFactory.addTwin() )
+                           .with( jwtTokenFactory.deleteTwin() )
                )
                .andDo( MockMvcResultHandlers.print() )
                .andExpect( status().isForbidden() );
+         mvc.perform(
+                     MockMvcRequestBuilders
+                           .post( LOOKUP_SHELL_BASE_PATH_POST )
+                           .contentType( MediaType.APPLICATION_JSON )
+                           .accept( MediaType.APPLICATION_JSON )
+                           .content( toJson( specificAssetIds ) )
+                           .with( jwtTokenFactory.addTwin() )
+               )
+               .andDo( MockMvcResultHandlers.print() )
+               .andExpect( status().isOk() );
          mvc.perform(
                      MockMvcRequestBuilders
                            .post( LOOKUP_SHELL_BASE_PATH_POST )


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

Fixes #553 by adding a matcher to cover the "POST /lookup/shellsByAssetLink" endpoint.

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
