### PR TITLE
feat: improve findExternalShellIdsByIdentifiersByExactMatch query

### DIFF
--- a/backend/src/main/java/org/eclipse/tractusx/semantics/registry/repository/H2ShellIdentifierRepository.java
+++ b/backend/src/main/java/org/eclipse/tractusx/semantics/registry/repository/H2ShellIdentifierRepository.java
@@ -1,0 +1,110 @@
+/*******************************************************************************
+ * Copyright (c) 2025 BMW AG
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.semantics.registry.repository;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+@Repository
+@Profile("test")
+public interface H2ShellIdentifierRepository extends ShellIdentifierRepository {
+
+    @Override
+    default List<String> findExternalShellIdsByIdentifiersByExactMatch(
+            @Param("namespaces") List<String> namespaces,
+            @Param("identifiers") List<String> identifiers,
+            @Param("pairCount") int pairCount,
+            @Param("tenantId") String tenantId,
+            @Param("publicWildcardPrefix") String publicWildcardPrefix,
+            @Param("publicWildcardAllowedTypes") List<String> publicWildcardAllowedTypes,
+            @Param("owningTenantId") String owningTenantId,
+            @Param("globalAssetId") String globalAssetId,
+            @Param("cutoffDate") Instant cutoffDate,
+            @Param("cursorValue") String cursorValue,
+            @Param("pageSize") int pageSize) {
+
+        // Concatenate namespaces and identifiers for H2 IN clause
+        List<String> keyValuePairs = new ArrayList<>();
+        for (int i = 0; i < namespaces.size(); i++) {
+            keyValuePairs.add(namespaces.get(i) + identifiers.get(i));
+        }
+
+        // Execute actual query with the converted parameters
+        return findExternalShellIdsByIdentifiersByExactMatchInternal(
+                keyValuePairs,
+                pairCount,
+                cutoffDate,
+                cursorValue,
+                tenantId,
+                owningTenantId,
+                globalAssetId,
+                publicWildcardPrefix,
+                publicWildcardAllowedTypes,
+                pageSize);
+    }
+
+    @Query( value = """
+            SELECT s.id_external
+            FROM shell s
+               JOIN shell_identifier si ON s.id = si.fk_shell_id
+            WHERE
+               CONCAT( si.namespace, si.identifier ) IN ( :keyValuePairs )
+               AND (
+                  s.created_date > :cutoffDate
+                  OR ( s.created_date = :cutoffDate AND s.id_external > :cursorValue )
+               )
+               AND (
+                  :tenantId = :owningTenantId
+                  OR si.namespace = :globalAssetId
+                  OR EXISTS (
+                     SELECT 1
+                     FROM SHELL_IDENTIFIER_EXTERNAL_SUBJECT_REFERENCE_KEY sider
+                        JOIN SHELL_IDENTIFIER_EXTERNAL_SUBJECT_REFERENCE sies ON sider.FK_SI_EXTERNAL_SUBJECT_REFERENCE_ID = sies.id
+                     WHERE
+                        (
+                           sider.ref_key_value = :tenantId
+                           OR ( sider.ref_key_value = :publicWildcardPrefix AND si.namespace IN (:publicWildcardAllowedTypes) )
+                        )
+                        AND sies.FK_SHELL_IDENTIFIER_EXTERNAL_SUBJECT_ID = si.id
+                  )
+               )
+            GROUP BY s.id_external, s.created_date
+            HAVING COUNT(*) = :pairCount
+            ORDER BY s.created_date, s.id_external
+            LIMIT :pageSize
+            """, nativeQuery = true )
+    List<String> findExternalShellIdsByIdentifiersByExactMatchInternal(
+            @Param("keyValuePairs") List<String> keyValuePairs,
+            @Param("pairCount") int pairCount,
+            @Param("cutoffDate") Instant cutoffDate,
+            @Param("cursorValue") String cursorValue,
+            @Param("tenantId") String tenantId,
+            @Param("owningTenantId") String owningTenantId,
+            @Param("globalAssetId") String globalAssetId,
+            @Param("publicWildcardPrefix") String publicWildcardPrefix,
+            @Param("publicWildcardAllowedTypes") List<String> publicWildcardAllowedTypes,
+            @Param("pageSize") int pageSize);
+}

--- a/backend/src/main/java/org/eclipse/tractusx/semantics/registry/repository/PostgreSqlShellIdentifierRepository.java
+++ b/backend/src/main/java/org/eclipse/tractusx/semantics/registry/repository/PostgreSqlShellIdentifierRepository.java
@@ -1,0 +1,96 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Robert Bosch Manufacturing Solutions GmbH and others
+ * Copyright (c) 2021 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License, Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ******************************************************************************/
+
+package org.eclipse.tractusx.semantics.registry.repository;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.Instant;
+import java.util.List;
+
+@Repository
+@Profile("!test")
+public interface PostgreSqlShellIdentifierRepository extends ShellIdentifierRepository {
+
+    /**
+     * Returns external shell ids for the given keyValueCombinations.
+     * External shell ids matching the conditions below are returned:
+     * - specificAssetIds match exactly the keyValueCombinations
+     * - if externalSubjectId (tenantId) is not null it must match the tenantId
+     * <p>
+     * <p>
+     * To be able to properly index the key and value conditions, the query does not use any functions.
+     * Computed indexes cannot be created for mutable functions like CONCAT in Postgres.
+     *
+     * @param namespaces  the namespace values to search for, making a tuple with the identifiers
+     * @param identifiers the identifier values to search for, making a tuple with the namespaces
+     * @return external shell ids for the given key value combinations
+     */
+    @Override
+    @Query(value = """
+                WITH shell_lookup AS (
+                SELECT s.id, s.id_external, s.created_date, si.namespace, si.identifier, si.id AS si_id
+                    FROM shell s
+                        JOIN shell_identifier si ON s.id = si.fk_shell_id
+                        WHERE (si.namespace, si.identifier) IN (
+                            SELECT unnest(:namespaces), unnest(:identifiers)
+                        )
+                        AND (s.created_date > :cutoffDate OR (s.created_date = :cutoffDate AND
+                            s.id_external > :cursorValue))
+                ) SELECT sl.id_external
+                FROM shell_lookup sl
+                WHERE :tenantId = :owningTenantId
+                    OR namespace = :globalAssetId
+                    OR EXISTS (
+                        SELECT 1
+                            FROM SHELL_IDENTIFIER_EXTERNAL_SUBJECT_REFERENCE_KEY sider
+                            JOIN SHELL_IDENTIFIER_EXTERNAL_SUBJECT_REFERENCE sies
+                                ON sider.FK_SI_EXTERNAL_SUBJECT_REFERENCE_ID = sies.id
+                            WHERE
+                                sies.FK_SHELL_IDENTIFIER_EXTERNAL_SUBJECT_ID = sl.si_id
+                                AND (
+                                    sider.ref_key_value = :tenantId
+                                    OR (
+                                        sider.ref_key_value = :publicWildcardPrefix
+                                        AND sl.namespace IN (:publicWildcardAllowedTypes)
+                                    )
+                                )
+                        )
+                GROUP BY sl.id_external, sl.created_date
+                HAVING COUNT(*) = :pairCount
+                ORDER BY sl.created_date, sl.id_external
+                LIMIT :pageSize;
+            """, nativeQuery = true)
+    List<String> findExternalShellIdsByIdentifiersByExactMatch(
+            @Param("namespaces") List<String> namespaces,
+            @Param("identifiers") List<String> identifiers,
+            @Param("pairCount") int pairCount,
+            @Param("tenantId") String tenantId,
+            @Param("publicWildcardPrefix") String publicWildcardPrefix,
+            @Param("publicWildcardAllowedTypes") List<String> publicWildcardAllowedTypes,
+            @Param("owningTenantId") String owningTenantId,
+            @Param("globalAssetId") String globalAssetId,
+            @Param("cutoffDate") Instant cutoffDate,
+            @Param("cursorValue") String cursorValue,
+            @Param("pageSize") int pageSize);
+}

--- a/backend/src/main/java/org/eclipse/tractusx/semantics/registry/service/ShellService.java
+++ b/backend/src/main/java/org/eclipse/tractusx/semantics/registry/service/ShellService.java
@@ -411,15 +411,24 @@ public class ShellService {
       }
    }
 
-   private List<String> fetchAPageOfAasIdsUsingLegacyAccessControl( final Set<ShellIdentifier> shellIdentifiers, final String externalSubjectId,
-         final String cursorValue, final int pageSize, final boolean isCursorAvailable, final OffsetDateTime createdAfter ) {
-      final var fetchSize = pageSize + 1;
-      final Instant cutoffDate = getCreatedDate( cursorValue, isCursorAvailable, createdAfter );
-      List<String> keyValueCombinations = toKeyValueCombinations( shellIdentifiers );
-      return shellIdentifierRepository.findExternalShellIdsByIdentifiersByExactMatch( keyValueCombinations,
-            keyValueCombinations.size(), externalSubjectId, externalSubjectIdWildcardPrefix, externalSubjectIdWildcardAllowedTypes, owningTenantId,
-            ShellIdentifier.GLOBAL_ASSET_ID_KEY, cutoffDate, cursorValue, fetchSize );
-   }
+    private List<String> fetchAPageOfAasIdsUsingLegacyAccessControl( final Set<ShellIdentifier> shellIdentifiers, final String externalSubjectId,
+                                                                     final String cursorValue, final int pageSize, final boolean isCursorAvailable, final OffsetDateTime createdAfter ) {
+        final var fetchSize = pageSize + 1;
+        final Instant cutoffDate = getCreatedDate( cursorValue, isCursorAvailable, createdAfter );
+
+        List<String> namespaces = new ArrayList<>();
+        List<String> identifiers = new ArrayList<>();
+
+        shellIdentifiers.forEach( shellIdentifier -> {
+            namespaces.add(shellIdentifier.getKey());
+            identifiers.add(shellIdentifier.getValue());
+        });
+
+        return shellIdentifierRepository.findExternalShellIdsByIdentifiersByExactMatch(
+                namespaces, identifiers, shellIdentifiers.size(),
+                externalSubjectId, externalSubjectIdWildcardPrefix, externalSubjectIdWildcardAllowedTypes, owningTenantId,
+                ShellIdentifier.GLOBAL_ASSET_ID_KEY, cutoffDate, cursorValue, fetchSize);
+    }
 
    /**
     * Retrieves the created date based on the cursor value and the availability of the cursor.


### PR DESCRIPTION
## Description
This PR aims to improve the performance of the query executed by calling the `/lookup/shellsByAssetLink` endpoint.

In order to focus the performance improvements in production scenarios, the focus was specifically on improving the query's performance on PostgreSQL databases. As such, the `unnest` function was used. As the `unnest` function is not globally supported (e.g. not supported by H2) , the decision split the `ShellIdentifierRepository` into two different database engine-specific interfaces was taken, and the `ShellIdentifierRepository` was prevented from being instantiated. Ence, the following repositories were created:

* `H2ShellIdentifierRepository`, which is the interface intended to be used when the datasource is H2, and
* `PostgreSqlShellIdentifierRepository`, which is the interface intended to be used when the datasource is PostgreSQL

Please note that in order to change as little behaviour as possible, the H2 interface is assumed to be used only when the active profile is `test`, and the PostgreSQL interface in any other case. The query improvement, as such, is only applied to the PostgreSQL implementation. 

## Query comparison

Below is a performance comparison between the currently implementated query and the new PostgreSQL query, for the same lookup. Please be aware that the used database is loaded with data, to ensure close similiarities to real usecases.
The `shell` table >3M rows, and the `shell_identifier` table contains >22M rows.

### Current query (still applied in the H2-specific repository)
<img width="1273" height="581" alt="Screenshot 2025-10-17 at 10 50 04" src="https://github.com/user-attachments/assets/ea16ba74-782f-4786-965a-4b3f6ed77ba7" />
<img width="1272" height="551" alt="Screenshot 2025-10-17 at 10 50 18" src="https://github.com/user-attachments/assets/791b0983-0962-4533-bfca-f61c9475b295" />

### New query (only applied in the PostgreSQL-specific repository)
<img width="1269" height="619" alt="Screenshot 2025-10-17 at 10 51 47" src="https://github.com/user-attachments/assets/d64202d0-5568-4df7-9bf9-c6144cb295b9" />
<img width="1272" height="619" alt="Screenshot 2025-10-17 at 10 51 58" src="https://github.com/user-attachments/assets/ad7fcd94-45d0-4afb-b3bb-a3dec29ee805" />

Note that the new PostgreSQL query is 4x faster than the current implementation

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
