### PR TITLE
fix: update sonar coverage configuration in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,7 +117,6 @@
 		<sonar.moduleKey>${project.groupId}:${project.artifactId}</sonar.moduleKey>
 		<sonar.projectName>sldt-digital-twin-registry</sonar.projectName>
 		<sonar.java.source>17</sonar.java.source>
-      <sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/backend/target/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
 	</properties>
 
 	<dependencyManagement>


### PR DESCRIPTION
This pull request makes a small change to the `pom.xml` configuration. The line specifying the JaCoCo coverage report path for SonarQube integration has been removed. This will affect how code coverage is reported in SonarQube.

* Removed the `sonar.coverage.jacoco.xmlReportPaths` property, which previously pointed to the JaCoCo XML report for backend coverage analysis.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
