### PR TITLE
Templated Helm parameter secret name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.12.0
+### Added
+### Changed
+### Fixed
+- Templated Helm Parameter tls.secretName
+
 ## 0.11.0
 ### Added
 ### Changed

--- a/charts/registry/Chart.yaml
+++ b/charts/registry/Chart.yaml
@@ -26,7 +26,7 @@ sources:
   - https://github.com/eclipse-tractusx/sldt-digital-twin-registry
 
 type: application
-version: 0.11.0
+version: 0.12.0
 appVersion: 0.11.0
 
 dependencies:

--- a/charts/registry/README.md
+++ b/charts/registry/README.md
@@ -108,7 +108,7 @@ helm install registry -n semantics . --create-namespace
 | registry.ingress.enabled | bool | `true` |  |
 | registry.ingress.rules | list | `[]` |  |
 | registry.ingress.tls.enabled | bool | `true` |  |
-| registry.ingress.tls.secretName | string | `"registry-certificate-secret"` |  |
+| registry.ingress.tls.secretName | string | `""` | TLS secret name used by the ingress. Leave empty to fall back to a release-unique default `"<release-fullname>-certificate-secret"`. Set explicitly when running multiple registry instances in the same namespace to guarantee unique secret names. |
 | registry.ingress.urlPrefix | string | `"/semantics/registry"` |  |
 | registry.livenessProbe.failureThreshold | int | `3` |  |
 | registry.livenessProbe.initialDelaySeconds | int | `100` |  |

--- a/charts/registry/templates/registry/registry-ingress.yaml
+++ b/charts/registry/templates/registry/registry-ingress.yaml
@@ -34,7 +34,7 @@ spec:
   tls:
     - hosts:
         - {{ .Values.registry.host }}
-      secretName: {{ .Values.registry.ingress.tls.secretName | default "registry-certificate-secret" }}
+      secretName: {{ .Values.registry.ingress.tls.secretName | default (printf "%s-certificate-secret" (include "dtr.fullname" .)) }}
   {{- else }}
     []  # Ensures tls is an empty list when not enabled
   {{- end }}

--- a/charts/registry/values.yaml
+++ b/charts/registry/values.yaml
@@ -80,8 +80,13 @@ registry:
     tls:
       ## enable tls, default false
       enabled: true
-      ## reuse secret in namespace with given name, default "registry-certificate-secret"
-      secretName: registry-certificate-secret
+      ## Reuse secret in namespace with given name.
+      ## When deploying multiple registry instances into the same namespace (e.g. sharing
+      ## a single cert-manager ClusterIssuer), this name MUST be unique per release to
+      ## avoid certificate / ingress conflicts.
+      ## If left empty, the chart will derive a unique default of the form
+      ## "<release-fullname>-certificate-secret".
+      secretName: ""
     ## use a urlPrefix to define a path of pathType "Prefix" with regex. Result is a path "/semantics/registry(/|$)(.*)"
     urlPrefix: /semantics/registry
     ## specify rules on your own, if the pathType Prefix + Regex runs into issues with your ClusterIssuer has a "strict-validate-path-type" check. -host.http.paths[0].path must at least be set. Then pathType "ImplementationSpecific" is used with common service name and port. Multiple paths may be specified


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
This pull request updates the Helm chart for the registry to improve how TLS secret names are handled, especially when deploying multiple registry instances in the same namespace. The main change is that the `tls.secretName` parameter is now optional and, if left empty, will default to a unique value based on the release name. This helps prevent certificate and ingress conflicts.

**Helm chart improvements for TLS secret handling:**

* The `tls.secretName` parameter in `values.yaml` and the ingress template is now optional; if not set, it defaults to `"<release-fullname>-certificate-secret"`, ensuring unique secret names for each release and avoiding conflicts when multiple registry instances are deployed in the same namespace. [[1]](diffhunk://#diff-34b86f308bdfb20b3f2782cdf6eead1095245b738b51849c2d740d1f6af029f2L83-R89) [[2]](diffhunk://#diff-4ab3fb09bab03820039182eb3ee2292ef536bb314ea1c379614a429a8c9e4adbL37-R37)
* Documentation in `README.md` and comments in `values.yaml` have been updated to explain the new behavior and recommend setting a unique secret name when running multiple instances in the same namespace. [[1]](diffhunk://#diff-da523fa8690e1aa62634e5848970812fea7b82d7cb5a3532c5f802189a5fa011L111-R111) [[2]](diffhunk://#diff-34b86f308bdfb20b3f2782cdf6eead1095245b738b51849c2d740d1f6af029f2L83-R89)

**Changelog update:**

* The `CHANGELOG.md` has been updated to note the templating of the Helm parameter `tls.secretName` as a fixed issue in version 0.12.0.

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [x] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [x] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files