### PR TITLE
fix: #603 instant-based cursor is effectively ignored in pagination of shell descriptors in legacy mode.

### DIFF
--- a/backend/src/main/java/org/eclipse/tractusx/semantics/registry/service/ShellService.java
+++ b/backend/src/main/java/org/eclipse/tractusx/semantics/registry/service/ShellService.java
@@ -286,12 +286,9 @@ public class ShellService {
         pageSize = getPageSize(pageSize);
         ShellCursor cursor = new ShellCursor(pageSize, cursorVal);
 
-        // Instant cursorCreatedDate = cursor.getShellSearchCursor();
-        String cVal = cursorVal;
-        if (cVal == null) {
-            cVal = DEFAULT_EXTERNAL_ID;
-        }
-        Instant cursorCreatedDate = getCreatedDate(cVal, cursorVal != null, createdAfter);
+        Instant cursorCreatedDate = cursor.hasCursorReceived()
+                ? cursor.getShellSearchCursor()
+                : Optional.ofNullable(createdAfter).map(OffsetDateTime::toInstant).orElse(MINIMUM_SQL_DATETIME);
 
         String extSubId = null;
         if (!externalSubjectId.isEmpty()) {

--- a/backend/src/test/java/org/eclipse/tractusx/semantics/registry/service/GranularShellServiceTest.java
+++ b/backend/src/test/java/org/eclipse/tractusx/semantics/registry/service/GranularShellServiceTest.java
@@ -105,6 +105,12 @@ class GranularShellServiceTest extends LegacyShellServiceTest {
       super.testsLookupWithThreePagesOfMatchingRecordsRequestingPageOfOnlyLastItemExpectSingleItemAndNoCursor();
    }
 
+   @Test
+   void testsFindAllShellsCursorPagination() {
+      createRule();
+      super.testsFindAllShellsCursorPagination();
+   }
+
    private void createRule() {
       String specificAssetIdName = keyPrefix + "key";
       String specificAssetIdValue = "value";

--- a/backend/src/test/java/org/eclipse/tractusx/semantics/registry/service/LegacyShellServiceTest.java
+++ b/backend/src/test/java/org/eclipse/tractusx/semantics/registry/service/LegacyShellServiceTest.java
@@ -40,7 +40,9 @@ import java.time.OffsetDateTime;
 import java.util.Base64;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import org.eclipse.tractusx.semantics.registry.dto.ShellCollectionDto;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -270,6 +272,26 @@ class LegacyShellServiceTest {
    
       }
 	  
+   @Test
+   void testsFindAllShellsCursorPagination() {
+      String specificAssetIdName = keyPrefix + "key";
+      String specificAssetIdValue = "value";
+      List<String> createdIds = IntStream.range( 0, 3 )
+            .mapToObj( i -> UuidCreator.getTimeOrderedEpoch().toString() )
+            .toList();
+      createdIds.forEach( id -> createShellWithIdAndSpecificAssetIds( id, specificAssetIdName, specificAssetIdValue ) );
+
+      ShellCollectionDto page1 = shellService.findAllShells( 2, null, TENANT_TWO, null );
+      assertThat( page1.getItems() ).isNotEmpty();
+      assertThat( page1.getCursor() ).as( "cursor must be present when more shells exist" ).isNotNull();
+
+      ShellCollectionDto page2 = shellService.findAllShells( 2, page1.getCursor(), TENANT_TWO, null );
+
+      Set<String> page1Ids = page1.getItems().stream().map( Shell::getIdExternal ).collect( Collectors.toSet() );
+      Set<String> page2Ids = page2.getItems().stream().map( Shell::getIdExternal ).collect( Collectors.toSet() );
+      assertThat( page1Ids ).doesNotContainAnyElementsOf( page2Ids );
+   }
+
    @Test
    void testsLookupWithLessThanAPageOfMatchingRecordsExpectPartialListAndNoCursorAndInValidCreatedDate() {
       final String specificAssetIdName = keyPrefix + "key";


### PR DESCRIPTION

<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

Fixes #603

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
