### PR TITLE
chore: pin GitHub Actions workflows to immutable SHA digests

### DIFF
--- a/.github/workflows/aas-registry-e2e-test.yml
+++ b/.github/workflows/aas-registry-e2e-test.yml
@@ -56,9 +56,9 @@ jobs:
           echo mask_edc_bpn=$mask_edc_bpn >> $GITHUB_ENV  
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
         with:
           python-version: "3.8"
           check-latest: true
@@ -80,7 +80,7 @@ jobs:
           EDC_BPN: ${{ env.mask_edc_bpn }}
 
       - name: Upload test report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: aas-registry-e2e-test-report

--- a/.github/workflows/build-snapshot.yml
+++ b/.github/workflows/build-snapshot.yml
@@ -38,9 +38,9 @@ jobs:
       contents: read
       packages: write 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           java-version: '17'
           distribution: 'adopt'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -48,17 +48,17 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           java-version: '17'
           distribution: 'temurin'
 
     # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
         with:
           languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -69,7 +69,7 @@ jobs:
           queries: +security-extended,security-and-quality
           
       - name: Cache maven packages
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # v3
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
@@ -94,6 +94,6 @@ jobs:
     #     ./location_of_script_within_repo/buildscript.sh
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
         with:
           category: "/language:${{matrix.language}}"

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -28,7 +28,7 @@ jobs:
       options: --user root
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: '0'
 
@@ -40,7 +40,7 @@ jobs:
           gitleaks detect -f sarif -r ./gitleaks-report-registry.sarif --exit-code 0
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: gitleaks-report
           path: ./gitleaks-report-registry.sarif
@@ -51,13 +51,13 @@ jobs:
     needs: gitleaks-run
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2.7.0
       - name: Download artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: gitleaks-report
       - name: Upload SARIF report
         if: always()
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@b8d3b6e8af63cde30bdc382c0bc28114f4346c88 # v2
         with:
           sarif_file: ./gitleaks-report-registry.sarif

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -36,7 +36,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
@@ -46,11 +46,11 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.4.1
+        uses: helm/chart-releaser-action@98bccfd32b0f76149d188912ac8e45ddd3f8695f # v1.4.1
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -43,12 +43,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
       - name: Kubernetes KinD Cluster
-        uses: container-tools/kind-action@v1
+        uses: container-tools/kind-action@fdfd7e7ffb39e532f9de844dba8f1a29ae7e0f75 # v1
         with:
           # upgrade version, default (v0.17.0) uses node image v1.21.1 and doesn't work with more recent node image versions
           version: v0.20.0
@@ -56,17 +56,17 @@ jobs:
           node_image: ${{ github.event.inputs.node_image || 'kindest/node:v1.27.3' }}
 
       - name: Set up Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3
         with:
           version: v3.9.3
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
         with:
           python-version: "3.9"
           check-latest: true
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.3.1
+        uses: helm/chart-testing-action@afea100a513515fbd68b0e72a7bb0ae34cb62aec # v2.3.1
 
       - name: Run chart-testing (list-changed)
         id: list-changed
@@ -83,7 +83,7 @@ jobs:
         if: github.event_name != 'pull_request' || steps.list-changed.outputs.changed == 'true'
 
       - name: Upload test report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         if: always()
         with:
           name: aas-registry-e2e-test-report

--- a/.github/workflows/hotfix-helm-release.yml
+++ b/.github/workflows/hotfix-helm-release.yml
@@ -33,7 +33,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
@@ -43,11 +43,11 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.4.1
+        uses: helm/chart-releaser-action@98bccfd32b0f76149d188912ac8e45ddd3f8695f # v1.4.1
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/hotfix-release.yml
+++ b/.github/workflows/hotfix-release.yml
@@ -50,11 +50,11 @@ jobs:
     permissions: 
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           java-version: '17'
           distribution: 'adopt'

--- a/.github/workflows/kics.yml
+++ b/.github/workflows/kics.yml
@@ -43,10 +43,10 @@ jobs:
       security-events: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: KICS scan
-        uses: checkmarx/kics-github-action@master
+        uses: checkmarx/kics-github-action@05aa5eb70eede1355220f4ca5238d96b397e30a6 # v2.1.20
         with:
           # Scanning directory .
           path: "."
@@ -68,6 +68,6 @@ jobs:
       # Upload findings to GitHub Advanced Security Dashboard
       - name: Upload SARIF file for GitHub Advanced Security Dashboard
         if: always()
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@b8d3b6e8af63cde30bdc382c0bc28114f4346c88 # v2
         with:
           sarif_file: kicsResults/results.sarif

--- a/.github/workflows/publish-edc-ext-to-maven-central.yml
+++ b/.github/workflows/publish-edc-ext-to-maven-central.yml
@@ -38,11 +38,11 @@ jobs:
     steps:
       - name: Checkout if workflow_dispatch
         if: ${{ github.event_name == 'workflow_dispatch' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: ${{ inputs.tag }}
       - name: setup-java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: temurin
           java-version: 17

--- a/.github/workflows/publish-image-registry.yml
+++ b/.github/workflows/publish-image-registry.yml
@@ -41,19 +41,19 @@ jobs:
     steps:
       - name: Checkout if push
         if: ${{ github.event_name == 'push' }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Checkout if workflow_dispatch
         if: ${{ github.event_name == 'workflow_dispatch' }}
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           ref: ${{ inputs.tag }}
       - name: setup-java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: temurin
           java-version: 17
       - name: Setup Maven Action
-        uses: s4u/setup-maven-action@v1.7.0
+        uses: s4u/setup-maven-action@94605e0cdfe442da48d603db22bbf4c7d203c076 # v1.7.0
         with:
           java-version: 17
       - name: execute-maven-deps
@@ -64,7 +64,7 @@ jobs:
         run: npm install
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@818d4b7b91585d195f67373fd9cb0332e31a7175 # v4
         with:
           images: |
             ${{ env.IMAGE_NAMESPACE }}/${{ env.IMAGE_NAME }}
@@ -75,12 +75,12 @@ jobs:
             type=semver,pattern={{major}}.{{minor}},value=${{ inputs.tag }}
             type=raw,value=latest,enable=${{ inputs.tag != '' }}
       - name: DockerHub login
-        uses: docker/login-action@v2
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
         with:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}
       - name: Build and push
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@1104d471370f9806843c095c1db02b5a90c5f8b6 # v3
         with:
           context: .
           push: true
@@ -88,7 +88,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
       - name: Update Docker Hub description
-        uses: peter-evans/dockerhub-description@v3
+        uses: peter-evans/dockerhub-description@dc67fad7001ef9e8e3c124cb7a64e16d0a63d864 # v3
         with:
           username: ${{ secrets.DOCKER_HUB_USER }}
           password: ${{ secrets.DOCKER_HUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,12 +50,12 @@ jobs:
     permissions: 
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
           ref: release
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@17f84c3641ba7b8f6deff6309fc4c864478f5d62 # v3
         with:
           java-version: '17'
           distribution: 'adopt'

--- a/.github/workflows/sonar-scan.yaml
+++ b/.github/workflows/sonar-scan.yaml
@@ -31,19 +31,19 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           java-version: '17'
           distribution: 'adopt'
           cache: maven
 
       - name: Cache SonarCloud packages
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -43,10 +43,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
 
       - name: Run Trivy vulnerability scanner in repo mode
-        uses: aquasecurity/trivy-action@0.24.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 #v0.36.0
         with:
           scan-type: "config"
           format: "sarif"
@@ -59,7 +59,7 @@ jobs:
           limit-severities-for-sarif: true
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e #v4.35.4
         if: always()
         with:
           sarif_file: "trivy-results1.sarif"
@@ -73,9 +73,9 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         
-      - uses: actions/setup-java@v4
+      - uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: 'temurin'
           java-version: '17'
@@ -84,7 +84,7 @@ jobs:
         run: mvn clean package
         
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.24.0
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 #v0.36.0
         with:
           image-ref: "tractusx/sldt-digital-twin-registry:latest"
           format: "sarif"
@@ -96,7 +96,7 @@ jobs:
           vuln-type: "os,library"
           limit-severities-for-sarif: true
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@68bde559dea0fdcac2102bfdf6230c5f70eb485e #v4.35.4
         if: always()
         with:
           sarif_file: "trivy-results-registry.sarif"

--- a/.github/workflows/veracode.yaml
+++ b/.github/workflows/veracode.yaml
@@ -34,11 +34,11 @@ jobs:
       security-events: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           ref: release
       - name: setup-java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: temurin
           java-version: 17
@@ -48,7 +48,7 @@ jobs:
           export REGISTRY_VERSION=$( mvn help:evaluate -Dexpression=project.version -q -DforceStdout )
           echo "REGISTRY_VERSION=$REGISTRY_VERSION" >> $GITHUB_ENV
       - name: Run Veracode Upload And Scan
-        uses: veracode/veracode-uploadandscan-action@0.2.1
+        uses: veracode/veracode-uploadandscan-action@c5e63c8383debb26a0d48250eab75d94327635ba # 0.2.1
         with:
           # Specify Veracode application name
           appname: "Digital Twin Registry"


### PR DESCRIPTION
## Description

Replaces all mutable GitHub Actions version tags (`@master`, `@v3`, `@v4`, etc.) with immutable 40-character commit SHAs across all 15 affected workflow files in `.github/workflows/`.

This is a supply-chain security hardening , the [OpenSSF Scorecard Pinned-Dependencies check](https://securityscorecards.dev), and SLSA guidelines. The [tj-actions/changed-files attack (CVE-2025-30066)](https://github.com/advisories/GHSA-mrrh-fwg8-r2c3) is a recent real-world example of what this prevents.

### Files patched (15) - trufflehog.yml was already fully pinned

- `kics.yml` - pinned `checkmarx/kics-github-action@master` + `codeql-action/upload-sarif@v2`
- `trivy.yml` - pinned `setup-java@v4`
- `codeql.yml` - pinned `setup-java@v4`, `codeql-action/init@v3`, `codeql-action/analyze@v3`, `cache@v3`
- `sonar-scan.yaml` - pinned `checkout@v4`, `setup-java@v4`, `cache@v4`
- `gitleaks.yml` - pinned `upload-artifact@v4`, `download-artifact@v4`, `codeql-action/upload-sarif@v2`
- `aas-registry-e2e-test.yml` - pinned `checkout@v4`, `setup-python@v4`, `upload-artifact@v4`
- `build-snapshot.yml` - pinned `checkout@v4`, `setup-java@v4`
- `helm-release.yml` - pinned `checkout@v4`, `azure/setup-helm@v3`, `helm/chart-releaser-action@v1.4.1`
- `helm-test.yml` - pinned `checkout@v4`, `kind-action@v1`, `setup-helm@v3`, `setup-python@v4`, `chart-testing-action@v2.3.1`, `upload-artifact@v4`
- `hotfix-helm-release.yml` - pinned `checkout@v4`, `setup-helm@v3`, `chart-releaser-action@v1.4.1`
- `hotfix-release.yml` - pinned `checkout@v4`, `setup-java@v4`
- `publish-edc-ext-to-maven-central.yml` - pinned `checkout@v4`, `setup-java@v4`
- `publish-image-registry.yml` - pinned `checkout@v4`, `checkout@v3`, `setup-java@v4`, `s4u/setup-maven-action@v1.7.0`, `docker/metadata-action@v4`, `docker/login-action@v2`, `docker/build-push-action@v3`, `peter-evans/dockerhub-description@v3`
- `release.yml` - pinned `checkout@v4`, `setup-java@v3`
- `veracode.yaml` - pinned `checkout@v4`, `setup-java@v4`, `veracode/veracode-uploadandscan-action@0.2.1`

All SHAs were verified against the respective upstream repositories via the GitHub Tags API.

## Pre-review checks

- [ ] DEPENDENCIES are up-to-date
- [ ] Copyright and license headers are present on all affected files
