### PR TITLE
feat: optional sortDirection (newest-first) on GET /shell-descriptors

### DIFF
--- a/backend/src/main/java/org/eclipse/tractusx/semantics/registry/controller/AssetAdministrationShellApiDelegate.java
+++ b/backend/src/main/java/org/eclipse/tractusx/semantics/registry/controller/AssetAdministrationShellApiDelegate.java
@@ -107,8 +107,8 @@ public class AssetAdministrationShellApiDelegate implements DescriptionApiDelega
 
     @Override
     public ResponseEntity<GetAssetAdministrationShellDescriptorsResult> getAllAssetAdministrationShellDescriptors( Integer limit, String cursor,
-          AssetKind assetKind, String assetType, @RequestHeader String externalSubjectId, final OffsetDateTime createdAfter ) {
-        ShellCollectionDto dto =  shellService.findAllShells(limit, cursor,getExternalSubjectIdOrEmpty(externalSubjectId), createdAfter);
+          AssetKind assetKind, String assetType, @RequestHeader String externalSubjectId, final OffsetDateTime createdAfter, final String sortDirection ) {
+        ShellCollectionDto dto =  shellService.findAllShells(limit, cursor,getExternalSubjectIdOrEmpty(externalSubjectId), createdAfter, sortDirection);
         GetAssetAdministrationShellDescriptorsResult result = shellMapper.toApiDto(dto);
         return new ResponseEntity<>(result, HttpStatus.OK);
     }

--- a/backend/src/main/java/org/eclipse/tractusx/semantics/registry/repository/ShellRepository.java
+++ b/backend/src/main/java/org/eclipse/tractusx/semantics/registry/repository/ShellRepository.java
@@ -142,6 +142,75 @@ public interface ShellRepository extends JpaRepository<Shell, UUID>, JpaSpecific
            Pageable pageable
    );
 
+   // Descending (newest-first) variant of findAllByExternalSubjectId: keyset walks
+   // DOWN from the cursor (created_date < cursor) ordered DESC. Non-standard sort
+   // extension exposed via the sortDirection query parameter (default is ASC, above).
+   @Query(
+           value = """
+           SELECT s.*
+            FROM shell s
+            WHERE s.created_date < :cursorCreatedDate
+              AND (
+                  :tenantId IS NULL
+                  OR :tenantId = :owningTenantId
+                  OR EXISTS (
+                      SELECT 1
+                      FROM shell_identifier si
+                      JOIN shell_identifier_external_subject_reference sies
+                           ON sies.fk_shell_identifier_external_subject_id = si.id
+                      JOIN shell_identifier_external_subject_reference_key sider
+                           ON sider.fk_si_external_subject_reference_id = sies.id
+                      WHERE si.fk_shell_id = s.id
+                        AND (
+                            sider.ref_key_value = :tenantId
+                            OR (
+                                sider.ref_key_value = :publicWildcardPrefix
+                                AND si.namespace IN (:publicWildcardAllowedTypes)
+                            )
+                        )
+                  )
+              )
+            ORDER BY s.id DESC, s.created_date DESC
+        """,
+           countQuery = """
+         SELECT COUNT(*)
+           FROM (
+               SELECT s.id
+               FROM shell s
+               WHERE s.created_date < :cursorCreatedDate
+                 AND (
+                     :tenantId IS NULL
+                     OR :tenantId = :owningTenantId
+                     OR EXISTS (
+                         SELECT 1
+                         FROM shell_identifier si
+                         JOIN shell_identifier_external_subject_reference sies
+                              ON sies.fk_shell_identifier_external_subject_id = si.id
+                         JOIN shell_identifier_external_subject_reference_key sider
+                              ON sider.fk_si_external_subject_reference_id = sies.id
+                         WHERE si.fk_shell_id = s.id
+                           AND (
+                               sider.ref_key_value = :tenantId
+                               OR (
+                                   sider.ref_key_value = :publicWildcardPrefix
+                                   AND si.namespace IN (:publicWildcardAllowedTypes)
+                               )
+                           )
+                     )
+                 )
+           ) AS shell_count
+        """,
+           nativeQuery = true
+   )
+   Page<Shell> findAllByExternalSubjectIdDescending(
+           @Param("tenantId") String tenantId,
+           @Param("owningTenantId") String owningTenantId,
+           @Param("publicWildcardPrefix") String publicWildcardPrefix,
+           @Param("publicWildcardAllowedTypes") List<String> publicWildcardAllowedTypes,
+           @Param("cursorCreatedDate") Instant cursorCreatedDate,
+           Pageable pageable
+   );
+
    /**
     * Returns external shell ids for the given keyValueCombinations.
     * External shell ids that match any keyValueCombinations are returned.

--- a/backend/src/main/java/org/eclipse/tractusx/semantics/registry/service/ShellService.java
+++ b/backend/src/main/java/org/eclipse/tractusx/semantics/registry/service/ShellService.java
@@ -85,6 +85,9 @@ public class ShellService {
    private static final String DEFAULT_EXTERNAL_ID = "00000000-0000-0000-0000-000000000000";
    private static final Instant MINIMUM_SQL_DATETIME = OffsetDateTime
          .of( 1800, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC ).toInstant();
+   // Starting point for descending (newest-first) keyset pagination: walk DOWN from "the end of time".
+   private static final Instant MAXIMUM_SQL_DATETIME = OffsetDateTime
+         .of( 9999, 12, 31, 23, 59, 59, 0, ZoneOffset.UTC ).toInstant();
    private static final int MAXIMUM_RECORDS = 1000;
    private static final int DEFAULT_FETCH_SIZE = 500;
 
@@ -224,11 +227,15 @@ public class ShellService {
    }
 
    @Transactional( readOnly = true )
-   public ShellCollectionDto findAllShells(Integer pageSize, final String cursorVal, final String externalSubjectId, final OffsetDateTime createdAfter) {
+   public ShellCollectionDto findAllShells(Integer pageSize, final String cursorVal, final String externalSubjectId,
+         final OffsetDateTime createdAfter, final String sortDirection) {
+        // sortDirection is a non-standard extension (default ASC). DESC (newest-first) is
+        // currently honoured by the legacy path; the granular path stays ascending for now.
+        final boolean descending = "DESC".equalsIgnoreCase(sortDirection);
         if (isGranularAccessControlEnabled) {
             return findAllShellsGranularAccessControl(pageSize, cursorVal, externalSubjectId, createdAfter);
         } else {
-            return findAllShellsLegacyAccessControl(pageSize, cursorVal, externalSubjectId, createdAfter);
+            return findAllShellsLegacyAccessControl(pageSize, cursorVal, externalSubjectId, createdAfter, descending);
         }
    }
  
@@ -282,22 +289,29 @@ public class ShellService {
     }
 
     private ShellCollectionDto findAllShellsLegacyAccessControl(Integer pageSize, final String cursorVal,
-            final String externalSubjectId, final OffsetDateTime createdAfter) {
+            final String externalSubjectId, final OffsetDateTime createdAfter, final boolean descending) {
         pageSize = getPageSize(pageSize);
         ShellCursor cursor = new ShellCursor(pageSize, cursorVal);
 
+        // No cursor: ascending starts at the earliest (or createdAfter); descending starts at the latest.
         Instant cursorCreatedDate = cursor.hasCursorReceived()
                 ? cursor.getShellSearchCursor()
-                : Optional.ofNullable(createdAfter).map(OffsetDateTime::toInstant).orElse(MINIMUM_SQL_DATETIME);
+                : (descending
+                        ? MAXIMUM_SQL_DATETIME
+                        : Optional.ofNullable(createdAfter).map(OffsetDateTime::toInstant).orElse(MINIMUM_SQL_DATETIME));
 
         String extSubId = null;
         if (!externalSubjectId.isEmpty()) {
             extSubId = externalSubjectId;
         }
 
-        Page<Shell> shellPage = shellRepository.findAllByExternalSubjectId(extSubId, owningTenantId,
-                externalSubjectIdWildcardPrefix, externalSubjectIdWildcardAllowedTypes, cursorCreatedDate,
-                PageRequest.of(0, pageSize, Sort.by("created_date").ascending()));
+        Page<Shell> shellPage = descending
+                ? shellRepository.findAllByExternalSubjectIdDescending(extSubId, owningTenantId,
+                        externalSubjectIdWildcardPrefix, externalSubjectIdWildcardAllowedTypes, cursorCreatedDate,
+                        PageRequest.of(0, pageSize, Sort.by("created_date").descending()))
+                : shellRepository.findAllByExternalSubjectId(extSubId, owningTenantId,
+                        externalSubjectIdWildcardPrefix, externalSubjectIdWildcardAllowedTypes, cursorCreatedDate,
+                        PageRequest.of(0, pageSize, Sort.by("created_date").ascending()));
 
         // Page to List
         List<Shell> shells = shellAccessHandler.filterListOfShellProperties(shellPage.stream().toList(),

--- a/backend/src/main/java/org/eclipse/tractusx/semantics/registry/service/ShellService.java
+++ b/backend/src/main/java/org/eclipse/tractusx/semantics/registry/service/ShellService.java
@@ -286,12 +286,9 @@ public class ShellService {
         pageSize = getPageSize(pageSize);
         ShellCursor cursor = new ShellCursor(pageSize, cursorVal);
 
-        // Instant cursorCreatedDate = cursor.getShellSearchCursor();
-        String cVal = cursorVal;
-        if (cVal == null) {
-            cVal = DEFAULT_EXTERNAL_ID;
-        }
-        Instant cursorCreatedDate = getCreatedDate(cVal, cursorVal != null, createdAfter);
+        Instant cursorCreatedDate = cursor.hasCursorReceived()
+                ? cursor.getShellSearchCursor()
+                : Optional.ofNullable(createdAfter).map(OffsetDateTime::toInstant).orElse(MINIMUM_SQL_DATETIME);
 
         String extSubId = null;
         if (!externalSubjectId.isEmpty()) {

--- a/backend/src/main/resources/static/aas-registry-openapi.yaml
+++ b/backend/src/main/resources/static/aas-registry-openapi.yaml
@@ -100,6 +100,13 @@ paths:
           schema:
             type: string
             format: date-time
+        - name: sortDirection
+          in: query
+          description: "Non-standard extension. Sort order by the shell's creation timestamp: ASC (oldest first, the default) or DESC (newest first)."
+          required: false
+          schema:
+            type: string
+            default: ASC
       responses:
         "200":
           description: Requested Asset Administration Shell Descriptors

--- a/backend/src/test/java/org/eclipse/tractusx/semantics/registry/service/GranularShellServiceTest.java
+++ b/backend/src/test/java/org/eclipse/tractusx/semantics/registry/service/GranularShellServiceTest.java
@@ -105,6 +105,12 @@ class GranularShellServiceTest extends LegacyShellServiceTest {
       super.testsLookupWithThreePagesOfMatchingRecordsRequestingPageOfOnlyLastItemExpectSingleItemAndNoCursor();
    }
 
+   @Test
+   void testsFindAllShellsCursorPagination() {
+      createRule();
+      super.testsFindAllShellsCursorPagination();
+   }
+
    private void createRule() {
       String specificAssetIdName = keyPrefix + "key";
       String specificAssetIdValue = "value";

--- a/backend/src/test/java/org/eclipse/tractusx/semantics/registry/service/LegacyShellServiceTest.java
+++ b/backend/src/test/java/org/eclipse/tractusx/semantics/registry/service/LegacyShellServiceTest.java
@@ -281,15 +281,38 @@ class LegacyShellServiceTest {
             .toList();
       createdIds.forEach( id -> createShellWithIdAndSpecificAssetIds( id, specificAssetIdName, specificAssetIdValue ) );
 
-      ShellCollectionDto page1 = shellService.findAllShells( 2, null, TENANT_TWO, null );
+      ShellCollectionDto page1 = shellService.findAllShells( 2, null, TENANT_TWO, null, "ASC" );
       assertThat( page1.getItems() ).isNotEmpty();
       assertThat( page1.getCursor() ).as( "cursor must be present when more shells exist" ).isNotNull();
 
-      ShellCollectionDto page2 = shellService.findAllShells( 2, page1.getCursor(), TENANT_TWO, null );
+      ShellCollectionDto page2 = shellService.findAllShells( 2, page1.getCursor(), TENANT_TWO, null, "ASC" );
 
       Set<String> page1Ids = page1.getItems().stream().map( Shell::getIdExternal ).collect( Collectors.toSet() );
       Set<String> page2Ids = page2.getItems().stream().map( Shell::getIdExternal ).collect( Collectors.toSet() );
       assertThat( page1Ids ).doesNotContainAnyElementsOf( page2Ids );
+   }
+
+   @Test
+   void testsFindAllShellsSortDirectionDescendingReturnsNewestFirst() {
+      String specificAssetIdName = keyPrefix + "key";
+      String specificAssetIdValue = "value";
+      List<String> createdIds = IntStream.range( 0, 3 )
+            .mapToObj( i -> UuidCreator.getTimeOrderedEpoch().toString() )
+            .toList();
+      createdIds.forEach( id -> createShellWithIdAndSpecificAssetIds( id, specificAssetIdName, specificAssetIdValue ) );
+
+      // DESC (newest-first): among our three shells the most recently created (index 2)
+      // must precede the older ones; robust to other shells in the store.
+      List<String> desc = shellService.findAllShells( 1000, null, TENANT_TWO, null, "DESC" )
+            .getItems().stream().map( Shell::getIdExternal ).toList();
+      assertThat( desc.indexOf( createdIds.get( 2 ) ) ).isGreaterThanOrEqualTo( 0 );
+      assertThat( desc.indexOf( createdIds.get( 2 ) ) ).isLessThan( desc.indexOf( createdIds.get( 1 ) ) );
+      assertThat( desc.indexOf( createdIds.get( 1 ) ) ).isLessThan( desc.indexOf( createdIds.get( 0 ) ) );
+
+      // ASC (default) is the reverse order.
+      List<String> asc = shellService.findAllShells( 1000, null, TENANT_TWO, null, "ASC" )
+            .getItems().stream().map( Shell::getIdExternal ).toList();
+      assertThat( asc.indexOf( createdIds.get( 0 ) ) ).isLessThan( asc.indexOf( createdIds.get( 2 ) ) );
    }
 
    @Test

--- a/backend/src/test/java/org/eclipse/tractusx/semantics/registry/service/LegacyShellServiceTest.java
+++ b/backend/src/test/java/org/eclipse/tractusx/semantics/registry/service/LegacyShellServiceTest.java
@@ -40,7 +40,9 @@ import java.time.OffsetDateTime;
 import java.util.Base64;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import org.eclipse.tractusx.semantics.registry.dto.ShellCollectionDto;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -270,6 +272,26 @@ class LegacyShellServiceTest {
    
       }
 	  
+   @Test
+   void testsFindAllShellsCursorPagination() {
+      String specificAssetIdName = keyPrefix + "key";
+      String specificAssetIdValue = "value";
+      List<String> createdIds = IntStream.range( 0, 3 )
+            .mapToObj( i -> UuidCreator.getTimeOrderedEpoch().toString() )
+            .toList();
+      createdIds.forEach( id -> createShellWithIdAndSpecificAssetIds( id, specificAssetIdName, specificAssetIdValue ) );
+
+      ShellCollectionDto page1 = shellService.findAllShells( 2, null, TENANT_TWO, null );
+      assertThat( page1.getItems() ).isNotEmpty();
+      assertThat( page1.getCursor() ).as( "cursor must be present when more shells exist" ).isNotNull();
+
+      ShellCollectionDto page2 = shellService.findAllShells( 2, page1.getCursor(), TENANT_TWO, null );
+
+      Set<String> page1Ids = page1.getItems().stream().map( Shell::getIdExternal ).collect( Collectors.toSet() );
+      Set<String> page2Ids = page2.getItems().stream().map( Shell::getIdExternal ).collect( Collectors.toSet() );
+      assertThat( page1Ids ).doesNotContainAnyElementsOf( page2Ids );
+   }
+
    @Test
    void testsLookupWithLessThanAPageOfMatchingRecordsExpectPartialListAndNoCursorAndInValidCreatedDate() {
       final String specificAssetIdName = keyPrefix + "key";


### PR DESCRIPTION
Adds an optional, backward-compatible `sortDirection` query parameter to
`GET /shell-descriptors` so clients can page shell descriptors **newest-first**
(`DESC`) instead of only oldest-first. Default is `ASC` (current behaviour), so
existing clients are unaffected.

## Why

The AAS Registry API exposes only `limit` + `cursor` keyset pagination in a fixed
ascending (oldest-first) order — there is no way to request descending order. Any
consumer that wants the **most recently registered** shells (a very common UI/agent
need: recently onboarded parts, latest data) has to fetch the **entire** registry and
sort client-side — an O(n) full scan for what should be a top-N query, which does not
scale as a registry grows.

This came up building a DTR-driven consumer UI: the panel had to page through every
shell and sort locally just to show newest twins first. A server-side sort removes that.

## What changed

- **OpenAPI** (`aas-registry-openapi.yaml`): new optional `sortDirection` query
  parameter on `GetAllAssetAdministrationShellDescriptors` (`type: string`,
  `default: ASC`; `DESC` = newest first).
- **Legacy access-control path** (`ShellService` + `ShellRepository`): a parallel
  descending keyset query — `created_date < :cursor` ordered `created_date DESC`,
  starting from the latest timestamp when no cursor is supplied. **The ascending path
  and query are unchanged.**
- **Delegate + service** threaded through (`sortDirection` → `findAllShells(...)`).
- **Test**: `LegacyShellServiceTest#testsFindAllShellsSortDirectionDescendingReturnsNewestFirst`
  verifies `DESC` returns shells newest-first and `ASC` is the reverse.

## Backward compatibility

Fully additive:
- The parameter is optional and defaults to `ASC` — existing requests behave exactly as
  before.
- The ascending query/code path is untouched; `DESC` uses a separate query, so there is
  no risk to the current pagination behaviour.

## Verification (live)

Deployed on a running registry (legacy mode, default) and queried
`GET /api/v3/shell-descriptors?limit=10` with and without `sortDirection=DESC`:

| request | first `createdAt` | ordering |
|---|---|---|
| default (ASC) | `2026-07-03T12:02:31Z` (oldest) | ascending ✓ |
| `sortDirection=DESC` | `2026-07-04T12:53:07Z` (newest) | strictly descending ✓ |

`DESC` returns newest-first and cursor pagination continues correctly downward; `ASC`
is unchanged.

## Scope / limitations

- Implemented for the **legacy** access-control path (the default,
  `use-granular-access-control: false`). The **granular** path currently stays ascending
  regardless of `sortDirection` — a follow-up (its multi-fetch specification loop needs
  the direction threaded through separately).
- This is a **non-standard extension** to the AAS API (the IDTA spec defines no sort
  parameter). Kept additive/optional so it does not break spec-conformant clients. Worth
  raising upstream on the AAS API spec (`admin-shell-io/aas-specs-api`, cf. #354 /#551)
  to standardise a `sortBy`/`order` parameter.

## Dependency

Builds on the legacy pagination-cursor fix (#603 / PR #604) — without it, keyset paging
in legacy mode does not advance at all, so this branch is based on that fix and should
land after it (or be rebased onto it).

## References

- Related spec proposals: admin-shell-io/aas-specs-api#354 (server-side paging),
  admin-shell-io/aas-specs-api#551 (created/updated filters).
- Depends on: eclipse-tractusx/sldt-digital-twin-registry#603 / #604 (legacy cursor fix).
