### PR TITLE
Fix : security issues 26.09 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.13.0-RC1
+### Added
+### Changed
+### Fixed
+- fixed security issue spring-boot-starter-parent. upgraded to 3.5.15
+- Update postgres dependency version to 42.7.12 and some other dependencies
+
 ## 0.12.0
 ### Added
 - Release 26.06

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 	<parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.14</version> <!-- need to be repeated in properties section for technical purposes -->
+        <version>3.5.15</version> <!-- need to be repeated in properties section for technical purposes -->
         <relativePath/> <!-- lookup parent from repository and not the filesystem -->
     </parent>
 
@@ -66,7 +66,7 @@
 
 		<!-- version properties -->
 		<!-- framework and base stuff -->
-		<spring.boot.version>3.5.14</spring.boot.version>
+		<spring.boot.version>3.5.15</spring.boot.version>
 		<springdoc.version>1.6.14</springdoc.version>
 		<lombok.version>1.18.34</lombok.version>
 		<swagger-annotations.version>1.5.20</swagger-annotations.version>
@@ -86,12 +86,12 @@
 
 		<!-- json, xml, formats, ... -->
 		<jackson.version>2.13.1</jackson.version>
-		<jackson.databind.version>2.22.1</jackson.databind.version>
-		<jackson.core.version>2.21.1</jackson.core.version>
+		<jackson.databind.version>2.21.4</jackson.databind.version>
+		<jackson.core.version>2.21.4</jackson.core.version>
 		<!-- persistence -->
 		<mapstruct.version>1.5.3.Final</mapstruct.version>
 		<mapstruct.lombok.version>0.2.0</mapstruct.lombok.version>
-		<postgresql.version>42.7.11</postgresql.version>
+		<postgresql.version>42.7.12</postgresql.version>
 		<h2.version>2.2.220</h2.version>
 		<liquibase.version>4.19.1</liquibase.version>
 


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
security issues 26.09 release
- fixed security issue spring-boot-starter-parent. upgraded to 3.5.15
- Update postgres dependency version to 42.7.12 and some other dependencies
- 
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
