### PR TITLE
Fix: Added .trivyignore to ignore a specific CVE from base image

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -83,16 +83,6 @@ jobs:
       - name: Build JAR
         run: mvn clean package
 
-      - name: Trivy scan - table
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 #v0.36.0
-        with:
-          image-ref: "tractusx/sldt-digital-twin-registry:latest"
-          format: table
-          severity: "CRITICAL,HIGH"
-          exit-code: 0
-          vuln-type: os,library
-          ignore-unfixed: false
-
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 #v0.36.0
         with:
@@ -104,6 +94,7 @@ jobs:
           hide-progress: false
           exit-code: "1" # Trivy exits with code 1 if vulnerabilities are found, causing the workflow step to fail.
           vuln-type: "os,library"
+          trivyignores: ".trivyignore"
           limit-severities-for-sarif: true
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 #v4.37.3

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,2 @@
+# CVE-2026-14456 is inherited from the Alpine base image
+CVE-2026-14456


### PR DESCRIPTION
<!-- 
Thanks for your contribution! 
Please follow the instructions on your PRs title and description.
aligned title description: '(feat|fix|chore|doc): _description of introduced change_'
Important: Contributing Guidelines can be found here: https://eclipse-tractusx.github.io/docs/oss/how-to-contribute
Info: <!- text comments ->  will be hidden from the rendered preview of your PR.
-->

## Description
Added .trivyignore to ignore a specific CVE from base image
<!-- 
Please describe your PR: 
- What does this PR introduce? 
- Does it fix a bug? 
- Does it add a new feature?
- Is it enhancing documentation?
-->

<!-- Please tag the related issue `Fixes or Updates #issue_number`, if applicable. -->

## Pre-review checks

Please ensure to do as many of the following checks as possible, before asking for committer review:

- [ ] DEPENDENCIES are up-to-date. [Dash license tool](https://github.com/eclipse/dash-licenses). Committers can open IP issues for restricted libs.
- [ ] [Copyright and license header](https://eclipse-tractusx.github.io/docs/release/trg-7/trg-7-02) are present on all affected files
